### PR TITLE
Field router add include field names

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Teraslice standard processor asset bundle",
     "license": "MIT",
     "private": true,

--- a/asset/src/field_router/processor.ts
+++ b/asset/src/field_router/processor.ts
@@ -11,7 +11,11 @@ export default class FieldRouter extends MapProcessor<FieldRouterConfig> {
 
         this.opConfig.fields.forEach((field) => {
             const fieldData = santize(toString(record[field]));
-            partitions.push(`${field}${this.opConfig.value_delimiter}${fieldData}`);
+            if (this.opConfig.include_field_names === true) {
+                partitions.push(`${field}${this.opConfig.value_delimiter}${fieldData}`);
+            } else {
+                partitions.push(`${fieldData}`);
+            }
         });
 
         record.setMetadata(

--- a/asset/src/field_router/schema.ts
+++ b/asset/src/field_router/schema.ts
@@ -25,6 +25,10 @@ export default class Schema extends ConvictSchema<FieldRouterConfig> {
                 doc: 'separator between the field name and the value - default "_"',
                 default: '_',
                 format: 'optional_String'
+            },
+            include_field_names: {
+                default: true,
+                format: 'Boolean'
             }
         };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard-assets-bundle",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Teraslice standard processor asset bundle",
     "private": true,
     "workspaces": [

--- a/test/fields_router/processor-spec.ts
+++ b/test/fields_router/processor-spec.ts
@@ -81,4 +81,22 @@ describe('Date path partitioner', () => {
         expect(slice2.getMetadata('standard:route')).toEqual('field2&val_2-field1&val_1');
         expect(slice3.getMetadata('standard:route')).toEqual('field2&val_2-field1&val_1');
     });
+    it('includes field name when include_field_names is true', async () => {
+        harness = await makeTest({ value_delimiter: '&', include_field_names: true });
+
+        const [slice1, slice2, slice3] = await harness.runSlice(data);
+
+        expect(slice1.getMetadata('standard:route')).toEqual('field2&val2-field1&val1');
+        expect(slice2.getMetadata('standard:route')).toEqual('field2&val_2-field1&val_1');
+        expect(slice3.getMetadata('standard:route')).toEqual('field2&val_2-field1&val_1');
+    });
+    it('does not include field name when include_field_names is false', async () => {
+        harness = await makeTest({ include_field_names: false });
+
+        const [slice1, slice2, slice3] = await harness.runSlice(data);
+
+        expect(slice1.getMetadata('standard:route')).toEqual('val2-val1');
+        expect(slice2.getMetadata('standard:route')).toEqual('val_2-val_1');
+        expect(slice3.getMetadata('standard:route')).toEqual('val_2-val_1');
+    });
 });


### PR DESCRIPTION
field_router
- Added include_field_names option to control if field names are include in route. 
- Defaults to true
