### PR TITLE
bumped the routed senders default size to 10k

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "Teraslice standard processor asset bundle",
     "license": "MIT",
     "private": true,

--- a/asset/src/routed_sender/schema.ts
+++ b/asset/src/routed_sender/schema.ts
@@ -31,7 +31,7 @@ export default class Schema extends ConvictSchema<RouteSenderConfig> {
         return {
             size: {
                 doc: 'the maximum number of docs it will take at a time, anything past it will be split up and sent',
-                default: 500,
+                default: 10000,
                 format(val: any) {
                     if (!isNumber(val)) {
                         throw new Error('Invalid size parameter for routed_sender opConfig, it must be a number');

--- a/docs/operations/routed_sender.md
+++ b/docs/operations/routed_sender.md
@@ -294,7 +294,7 @@ export default class FileSender implements RouteSenderAPI {
 | Configuration | Description | Type |  Notes |
 | --------- | -------- | ------ | ------ |
 | _op | Name of operation, it must reflect the exact name of the file | String | required |
-| size | the maximum number of docs it will take at a time, anything past it will be split up and sent according to the `concurrency` setting | Number | optional, defaults to 500 |
+| size | the maximum number of docs it will take at a time, anything past it will be split up and sent according to the `concurrency` setting | Number | optional, defaults to 10000 |
 | concurrency | The number of inflight calls to the api.send allowed | Number | optional, defaults to 10 |
 | api_name | The name of the api that will be used | String | required |
 | routing | Mapping of `standard:route` metadata to connection names. Routes data to multiple clusters based on the incoming key. The key name can be a comma separated list of prefixes that will map to the same connection | Object | required |


### PR DESCRIPTION
Bumped the routed_sender's size default property to 10k.  Not sure if there was a reason it was only 500, but in using this with the kafka_api the default value caused issues.  Also 10K is a typical value for the es sender size and since the router_senders values overwrites the size settings in the api I think that 10k makes more sense as a default size setting here.


Also bumped the asset version to 0.12.1


