### PR TITLE
bumped asset version 

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "Teraslice standard processor asset bundle",
     "license": "MIT",
     "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard-assets-bundle",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "Teraslice standard processor asset bundle",
     "private": true,
     "workspaces": [


### PR DESCRIPTION
* bumped asset version to 0.12.2
* indicates change to how the bundled asset is built, which fixes transforms op issues in the bundled asset