### PR TITLE
routed_sender: delimiter validation, schema delimiter name changes, expanded tests, updated documentation

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.12.3",
+    "version": "0.13.0",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "0.12.3",
+    "version": "0.13.0",
     "description": "Teraslice standard processor asset bundle",
     "license": "MIT",
     "private": true,

--- a/asset/src/date_router/processor.ts
+++ b/asset/src/date_router/processor.ts
@@ -20,7 +20,7 @@ export default class DateRouter extends MapProcessor<DateRouterConfig> {
 
         record.setMetadata(
             'standard:route',
-            indexParts.join(this.opConfig.field_delimiter)
+            indexParts.join(this.opConfig.date_delimiter)
         );
     }
 
@@ -93,7 +93,7 @@ export default class DateRouter extends MapProcessor<DateRouterConfig> {
     }
 
     private _joinValue(key: string, value: string | number) {
-        if (this.opConfig.include_date_units) return `${key}${this.opConfig.value_delimiter}${value}`;
+        if (this.opConfig.include_date_units) return `${key}${this.opConfig.date_unit_delimiter}${value}`;
         return `${value}`;
     }
 }

--- a/asset/src/date_router/schema.ts
+++ b/asset/src/date_router/schema.ts
@@ -1,6 +1,14 @@
 import { ConvictSchema } from '@terascope/job-components';
 import { DateRouterConfig, DateResolution } from './interfaces';
 
+const validDelimiters = [
+    '-',
+    '_',
+    '.',
+    '/',
+    ''
+];
+
 export default class Schema extends ConvictSchema<DateRouterConfig> {
     build(): Record<string, any> {
         return {
@@ -14,15 +22,15 @@ export default class Schema extends ConvictSchema<DateRouterConfig> {
                 default: DateResolution.daily,
                 format: Object.keys(DateResolution)
             },
-            field_delimiter: {
-                doc: 'separator between field/value combinations - default "-"',
-                default: '-',
-                format: 'optional_String'
+            date_delimiter: {
+                doc: 'separator between the date parts, ie year, month, date',
+                default: '.',
+                format: (value: string) => this.validateDelimiter(value)
             },
-            value_delimiter: {
-                doc: 'separator between the field name and the value - default "_"',
+            date_unit_delimiter: {
+                doc: 'separator between the date unit and the date value, only used if include_date_units is true.  Defaults to "_"',
                 default: '_',
-                format: 'optional_String'
+                format: (value: string) => this.validateDelimiter(value)
             },
             include_date_units: {
                 doc: 'determines if the date unit (year, month, day) should be included in final output',
@@ -30,5 +38,11 @@ export default class Schema extends ConvictSchema<DateRouterConfig> {
                 format: 'Boolean'
             }
         };
+    }
+
+    validateDelimiter(value: string): void {
+        if (!validDelimiters.includes(value)) {
+            throw Error(`Delimiter must be one of ${validDelimiters.join(',')}, value was ${value}`);
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard-assets-bundle",
-    "version": "0.12.3",
+    "version": "0.13.0",
     "description": "Teraslice standard processor asset bundle",
     "private": true,
     "workspaces": [

--- a/test/date_router/processor-spec.ts
+++ b/test/date_router/processor-spec.ts
@@ -40,7 +40,17 @@ describe('date_router', () => {
         });
 
         const [slice] = await test.runSlice(data);
-        expect(slice.getMetadata('standard:route')).toEqual('2020-01-17');
+        expect(slice.getMetadata('standard:route')).toEqual('2020.01.17');
+    });
+
+    it('properly adds a daily parameter with no delimiter', async () => {
+        const test = await makeTest({
+            resolution: DateResolution.daily,
+            date_delimiter: ''
+        });
+
+        const [slice] = await test.runSlice(data);
+        expect(slice.getMetadata('standard:route')).toEqual('20200117');
     });
 
     it('properly adds a daily parameter with fields', async () => {
@@ -50,7 +60,19 @@ describe('date_router', () => {
         });
 
         const [slice] = await test.runSlice(data);
-        expect(slice.getMetadata('standard:route')).toEqual('year_2020-month_01-day_17');
+        expect(slice.getMetadata('standard:route')).toEqual('year_2020.month_01.day_17');
+    });
+
+    it('properly adds a daily parameter with fields and no date_unit_delimiter', async () => {
+        const test = await makeTest({
+            resolution: DateResolution.daily,
+            include_date_units: true,
+            date_delimiter: '-',
+            date_unit_delimiter: ''
+        });
+
+        const [slice] = await test.runSlice(data);
+        expect(slice.getMetadata('standard:route')).toEqual('year2020-month01-day17');
     });
 
     it('properly adds a weekly parameter', async () => {
@@ -59,12 +81,13 @@ describe('date_router', () => {
         });
 
         const [slice] = await test.runSlice(data);
-        expect(slice.getMetadata('standard:route')).toEqual('2020-02');
+        expect(slice.getMetadata('standard:route')).toEqual('2020.02');
     });
 
     it('properly adds a weekly parameter for weeks greater than 10', async () => {
         const test = await makeTest({
-            resolution: DateResolution.weekly
+            resolution: DateResolution.weekly,
+            date_delimiter: '-'
         });
 
         data[0].date = '2021-08-22T19:21:52.159Z';
@@ -76,7 +99,8 @@ describe('date_router', () => {
     it('properly adds a weekly parameter with fields', async () => {
         const test = await makeTest({
             resolution: DateResolution.weekly,
-            include_date_units: true
+            include_date_units: true,
+            date_delimiter: '-'
         });
 
         const [slice] = await test.runSlice(data);
@@ -108,38 +132,39 @@ describe('date_router', () => {
         });
 
         const slice = await test.runSlice(data);
-        expect(slice[0].getMetadata('standard:route')).toEqual('2020-01');
+        expect(slice[0].getMetadata('standard:route')).toEqual('2020.01');
     });
 
     it('properly adds a monthly parameter with fields', async () => {
         const test = await makeTest({
             resolution: DateResolution.monthly,
-            include_date_units: true
+            include_date_units: true,
+            date_delimiter: '-'
         });
 
         const slice = await test.runSlice(data);
         expect(slice[0].getMetadata('standard:route')).toEqual('year_2020-month_01');
     });
 
-    it('properly adds a monthly parameter with another field_delimiter', async () => {
+    it('properly adds a monthly parameter with another date_delimiter', async () => {
         const test = await makeTest({
             resolution: DateResolution.monthly,
-            field_delimiter: '.'
+            date_delimiter: '.'
         });
 
         const slice = await test.runSlice(data);
         expect(slice[0].getMetadata('standard:route')).toEqual('2020.01');
     });
 
-    it('properly adds a monthly parameter with another field_delimiter with fields', async () => {
+    it('properly adds a monthly parameter with another date_delimiter with fields', async () => {
         const test = await makeTest({
             resolution: DateResolution.monthly,
-            field_delimiter: ' > ',
+            date_delimiter: '.',
             include_date_units: true
         });
 
         const slice = await test.runSlice(data);
-        expect(slice[0].getMetadata('standard:route')).toEqual('year_2020 > month_01');
+        expect(slice[0].getMetadata('standard:route')).toEqual('year_2020.month_01');
     });
 
     it('properly adds a yearly parameter', async () => {
@@ -161,24 +186,24 @@ describe('date_router', () => {
         expect(slice[0].getMetadata('standard:route')).toEqual('year_2020');
     });
 
-    it('properly does not add a yearly parameter with another value_delimiter if include_date_units is set to true', async () => {
+    it('properly does not add a yearly parameter with another date_unit_delimiter if include_date_units is set to true', async () => {
         const test = await makeTest({
             resolution: DateResolution.yearly,
-            value_delimiter: '&'
+            date_unit_delimiter: '/'
         });
 
         const slice = await test.runSlice(data);
         expect(slice[0].getMetadata('standard:route')).toEqual('2020');
     });
 
-    it('properly adds a yearly parameter with another value_delimiter with fields', async () => {
+    it('properly adds a yearly parameter with another date_unit_delimiter with fields', async () => {
         const test = await makeTest({
             resolution: DateResolution.yearly,
-            value_delimiter: '&',
+            date_unit_delimiter: '/',
             include_date_units: true
         });
 
         const slice = await test.runSlice(data);
-        expect(slice[0].getMetadata('standard:route')).toEqual('year&2020');
+        expect(slice[0].getMetadata('standard:route')).toEqual('year/2020');
     });
 });

--- a/test/date_router/schema-spec.ts
+++ b/test/date_router/schema-spec.ts
@@ -30,14 +30,17 @@ describe('date_router schema', () => {
         expect(schema).toBeDefined();
         expect(schema.field).toEqual('test');
         expect(schema.resolution).toEqual(DateResolution.daily);
-        expect(schema.field_delimiter).toEqual('-');
-        expect(schema.value_delimiter).toEqual('_');
+        expect(schema.date_delimiter).toEqual('.');
+        expect(schema.date_unit_delimiter).toEqual('_');
     });
 
     it('should throw with bad values', async () => {
         await expect(makeSchema({})).toReject();
         await expect(makeSchema({ field: 'test', resolution: 1234 })).toReject();
-        await expect(makeSchema({ field: 'test', field_delimiter: 1234 })).toReject();
-        await expect(makeSchema({ field: 'test', value_delimiter: 1234 })).toReject();
+        await expect(makeSchema({ field: 'test', date_delimiter: 1234 })).toReject();
+        await expect(makeSchema({ field: 'test', date_unit_delimiter: 1234 })).toReject();
+        await expect(makeSchema({ field: 'test', date_delimiter: ':' })).toReject();
+        await expect(makeSchema({ field: 'test', date_unit_delimiter: '*' })).toReject();
+        await expect(makeSchema({ field: 'test', date_unit_delimiter: ' ' })).toReject();
     });
 });


### PR DESCRIPTION
changes to routed_sender:
  * changed delimiter names to `date_delimiter` and `date_unit_delimiter` to communicate where the delimiters are applied, this is a breaking change from past versions
  * set the delimiter defaults to reflect common use cases
  * added delimiter limitations and validation - only `/`, `-`, `_`, `.`, or empty quotes (no delimiter) are available to be used as delimiters
  * updated documentation
  * bumped asset to version 0.13.0 