### PR TITLE
Added support for appending a suffix to the key route in the KeyRouter

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.14.3",
+    "version": "0.15.0",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "0.14.3",
+    "version": "0.15.0",
     "description": "Teraslice standard processor asset bundle",
     "license": "MIT",
     "private": true,
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@terascope/job-components": "^0.56.1",
-        "@terascope/standard-asset-apis": "^0.2.3",
+        "@terascope/standard-asset-apis": "^0.3.0",
         "@terascope/utils": "^0.44.1",
         "express": "^4.17.3",
         "mocker-data-generator": "^2.12.0",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "Teraslice standard processor asset bundle",
     "license": "MIT",
     "private": true,
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@terascope/job-components": "^0.56.1",
-        "@terascope/standard-asset-apis": "^0.2.2",
+        "@terascope/standard-asset-apis": "^0.2.3",
         "@terascope/utils": "^0.44.1",
         "express": "^4.17.3",
         "mocker-data-generator": "^2.12.0",

--- a/asset/src/key_router/schema.ts
+++ b/asset/src/key_router/schema.ts
@@ -1,5 +1,5 @@
 import {
-    ConvictSchema, isNumber, ValidatedJobConfig, getOpConfig, OpConfig
+    ConvictSchema, isNumber, ValidatedJobConfig, getOpConfig, OpConfig, isBoolean, isString
 } from '@terascope/job-components';
 import { KeyRouterConfig, KeyRouterFromOptions, KeyRouterCaseOptions } from '@terascope/standard-asset-apis';
 
@@ -8,6 +8,16 @@ export default class Schema extends ConvictSchema<KeyRouterConfig & OpConfig> {
         const op = getOpConfig(job, 'key_router') as KeyRouterConfig;
         if ((op.from && !op.use) || (!op.from && op.use)) {
             throw new Error('Invalid parameters, if "from" or "use" are specified, they must be used together');
+        }
+        if (op.suffix_use && (!op.use || !op.from)) {
+            throw new Error('Invalid parameters, if "suffix_use" is specified then "from" and "use" should be specified, they must be used together');
+        }
+        if (op.suffix_use
+            && op.suffix_upper === ''
+            && op.suffix_lower === ''
+            && op.suffix_other === ''
+            && op.suffix_number === '') {
+            throw new Error('Invalid parameters, suffix_use requires that at least one suffix_(upper/lower/other/number) value be specified');
         }
     }
 
@@ -37,7 +47,53 @@ export default class Schema extends ConvictSchema<KeyRouterConfig & OpConfig> {
                 doc: 'transform to apply to the values extracted from the key',
                 default: KeyRouterCaseOptions.preserve,
                 format: Object.keys(KeyRouterCaseOptions)
+            },
+            suffix_use: {
+                doc: 'append suffix to extracted value',
+                default: false,
+                format: (val: any) => {
+                    if (val !== undefined) {
+                        if (!isBoolean(val)) throw new Error('Parameter "suffix_use" must be a boolean');
+                    }
+                }
+            },
+            suffix_upper: {
+                doc: 'suffix value to append to extracted value for upper case values',
+                default: '',
+                format: (val: any) => {
+                    if (val !== undefined) {
+                        if (!isString(val)) throw new Error('Parameter "suffix_upper" must be a string');
+                    }
+                }
+            },
+            suffix_lower: {
+                doc: 'suffix value to append to extracted value for upper case values',
+                default: '',
+                format: (val: any) => {
+                    if (val !== undefined) {
+                        if (!isString(val)) throw new Error('Parameter "suffix_lower" must be a string');
+                    }
+                }
+            },
+            suffix_number: {
+                doc: 'suffix value to append to extracted value for number values',
+                default: '',
+                format: (val: any) => {
+                    if (val !== undefined) {
+                        if (!isString(val)) throw new Error('Parameter "suffix_number" must be a string');
+                    }
+                }
+            },
+            suffix_other: {
+                doc: 'suffix value to append to extracted value when value is not a letter or number',
+                default: '',
+                format: (val: any) => {
+                    if (val !== undefined) {
+                        if (!isString(val)) throw new Error('Parameter "suffix_other" must be a string');
+                    }
+                }
             }
+
         };
     }
 }

--- a/docs/operations/key_router.md
+++ b/docs/operations/key_router.md
@@ -87,7 +87,7 @@ results[1].getMetadata('standard:route') === 'secondkey';
 ### Use a partial of _key value
 Here is an example of creating a route from part of the `_key` value
 
-Example Job
+Example Job:
 
 ```json
 {
@@ -128,6 +128,52 @@ Example Job
 
 ```
 
+### Add Suffix Example
+
+Example:
+```json
+{
+    "name" : "testing",
+    "workers" : 1,
+    "slicers" : 1,
+    "lifecycle" : "once",
+    "assets" : [
+        "standard",
+        "elasticsearch"
+    ],
+    "apis": [
+         {
+            "_name": "elasticsearch_sender_api",
+            "index": "other_index",
+            "size": 1000
+        }
+    ],
+    "operations" : [
+        {
+            "_op": "test-reader",
+        },
+        {
+            "_op": "key_router",
+            "use:": 1,
+            "from": "beginning",
+            "case": "lower",
+            "suffix_use": true,
+            "suffix_upper": "--u",
+            "suffix_lower": "--l",
+            "suffix_number": "--n",
+            "suffix_other": "--c"
+        },
+        {
+            "_op": "routed_sender",
+            "api_name": "elasticsearch_sender_api",
+            "routing": {
+                "**": "default"
+            }
+        }
+    ]
+}
+```
+
 Here is an example of data and the resulting metadata generated from it based on the job above.
 
 ```javascript
@@ -160,12 +206,16 @@ results[0].getMetadata('standard:route') === 'f';
 results[1].getMetadata('standard:route') === 's';
 ```
 
-
 ## Parameters
 
-| Configuration | Description                                                                                            | Type   | Notes                                                        |
-| ------------- | ------------------------------------------------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
-| _op           | Name of operation, it must reflect the exact name of the file                                          | String | required                                                     |
-| use           | The number of characters to slice off the key and use as the routing value'                            | Number | optional, if used it must be used in conjunction with `from` |
-| from          | Whether the characters are sliced from the `beginning` or `end` of the key                             | String | optional, if used it must be used in conjunction with `use`  |
-| case          | Transform to apply to the values extracted from the key, may be set to `preserve`, `lower`, or `upper` | String | optional, defaults to preserve                               |
+| Configuration | Description                                                                                             | Type    | Notes                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------ |
+| _op           | Name of operation, it must reflect the exact name of the file                                           | String  | required                                                     |
+| use           | The number of characters to slice off the key and use as the routing value'                             | Number  | optional, if used it must be used in conjunction with `from` |
+| from          | Whether the characters are sliced from the `beginning` or `end` of the key                              | String  | optional, if used it must be used in conjunction with `use`  |
+| case          | Transform to apply to the values extracted from the key, may be set to `preserve`, `lower`, or `upper`  | String  | optional, defaults to preserve                               |
+| suffix_use    | Append a suffix to the extracted value.  The extracted value and be from the `beginning` or `end`.  The value of the suffix can be altered by using `case`.  When using with Elasticsearch the use `"case": "lower"`.  When using with `use` greater than one there is a risk of clobbering the case of the extracted values. | Boolean | optional, defaults to false requires at list one suffix_(upper/lower/number/other) |
+| suffix_upper  | Suffix value to be appended to the extracted value when the value is an upper case letter.              | String  | optional, defaults to `''`                                   |
+| suffix_lower  | Suffix value to be appended to the extracted value when the value is a lower case letter.               | String  | optional, defaults to `''`                                   |
+| suffix_number | Suffix value to be appended to the extracted value when the value is a number.                          | String  | optional, defaults to `''`                                   |
+| suffix_other  | Suffix value to be appended to the extracted value when the value is a neither letter or number.        | String  | optional, defaults to `''`                                   |

--- a/docs/operations/key_router.md
+++ b/docs/operations/key_router.md
@@ -11,6 +11,7 @@ Please be aware of the constraints for the particular destination api you are us
 ## Usage
 
 ### Use the whole _key value but lowercase it
+
 Here is an example of creating a route valid and changing the case of it
 
 Example Job
@@ -85,6 +86,7 @@ results[1].getMetadata('standard:route') === 'secondkey';
 ```
 
 ### Use a partial of _key value
+
 Here is an example of creating a route from part of the `_key` value
 
 Example Job:
@@ -131,6 +133,7 @@ Example Job:
 ### Add Suffix Example
 
 Example:
+
 ```json
 {
     "name" : "testing",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard-assets-bundle",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "description": "Teraslice standard processor asset bundle",
     "private": true,
     "workspaces": [
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@terascope/eslint-config": "^0.7.1",
         "@terascope/job-components": "^0.56.1",
-        "@terascope/standard-asset-apis": "^0.2.2",
+        "@terascope/standard-asset-apis": "^0.2.3",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.4.0",
         "@types/json2csv": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "standard-assets-bundle",
-    "version": "0.14.3",
+    "version": "0.15.0",
     "description": "Teraslice standard processor asset bundle",
     "private": true,
     "workspaces": [
@@ -27,7 +27,7 @@
     "devDependencies": {
         "@terascope/eslint-config": "^0.7.1",
         "@terascope/job-components": "^0.56.1",
-        "@terascope/standard-asset-apis": "^0.2.3",
+        "@terascope/standard-asset-apis": "^0.3.0",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.4.0",
         "@types/json2csv": "^5.0.3",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/standard-asset-apis",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "description": "A common set of tools for data processing",
     "publishConfig": {
         "access": "public"

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/standard-asset-apis",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "A common set of tools for data processing",
     "publishConfig": {
         "access": "public"

--- a/packages/standard-asset-apis/src/routers/KeyRouter.ts
+++ b/packages/standard-asset-apis/src/routers/KeyRouter.ts
@@ -78,7 +78,6 @@ export interface KeyRouterConfig {
 }
 
 function extraction(config: KeyRouterConfig): (key: string) => string {
-
     // set suffix defaults
     const suffixUpper = config.suffix_upper ?? '';
     const suffixLower = config.suffix_lower ?? '';
@@ -90,10 +89,10 @@ function extraction(config: KeyRouterConfig): (key: string) => string {
         if (config.use === 0) {
             throw new RangeError('KeyRouter requires that at least one character is selected, use must be greater than 0');
         }
-        if (config.use > 1 && config.case !== 'preserve' && suffixUse ) {
+        if (config.use > 1 && config.case !== 'preserve' && suffixUse) {
             throw new RangeError('KeyRouter may clobber keys when changing case with more than one routing key');
         }
-        if (config.use > 1 && config.case === 'preserve' && suffixUse ) {
+        if (config.use > 1 && config.case === 'preserve' && suffixUse) {
             throw new RangeError('KeyRouter with suffix_use:true only works with use:1');
         }
 
@@ -109,17 +108,18 @@ function extraction(config: KeyRouterConfig): (key: string) => string {
         if (end === 1 && suffixUse) {
             return (key) => {
                 const val = key.slice(0, end);
+                let routingKey: string;
                 if (/[A-Z]/.test(val)) {
-                    return suffixUse ? `${val.toLowerCase()}${suffixUpper}`: val
+                    routingKey = suffixUse ? `${val.toLowerCase()}${suffixUpper}` : val;
                 } else if (/[a-z]/.test(val)) {
-                    return suffixUse ? `${val}${suffixLower}` : val
+                    routingKey = suffixUse ? `${val}${suffixLower}` : val;
                 } else if (/[0-9]/.test(val)) {
-                    return suffixUse ? `${val}${suffixNumber}` : val
+                    routingKey = suffixUse ? `${val}${suffixNumber}` : val;
                 } else {
-                    return suffixUse ? `${val}${suffixOther}` : val
+                    routingKey = suffixUse ? `${val}${suffixOther}` : val;
                 }
+                return routingKey;
             };
-
         }
 
         return (key) => key.slice(0, end);

--- a/packages/standard-asset-apis/src/routers/KeyRouter.ts
+++ b/packages/standard-asset-apis/src/routers/KeyRouter.ts
@@ -92,11 +92,8 @@ export class KeyRouter implements I.Router {
 
         const extractionFn = this.extraction();
         const caseFn = this.caseTransforms(this.config.case);
-        // TODO with this order the suffix will be incorrect because the case gets coverted
-        // first, losing the original value of the routing key
-        // this.transformKey = (key) => this.addSuffix(caseFn((extractionFn(key))));
 
-        // TODO The ordrer case function converts the suffix to uppercase when using case upper
+        // With this order the case function converts the suffix to uppercase when using case upper
         this.transformKey = (key) => caseFn(this.addSuffix((extractionFn(key))));
     }
 

--- a/packages/standard-asset-apis/src/routers/KeyRouter.ts
+++ b/packages/standard-asset-apis/src/routers/KeyRouter.ts
@@ -1,25 +1,7 @@
-import { DataEntity } from '@terascope/utils';
+import { DataEntity, debugLogger } from '@terascope/utils';
 import * as I from './interfaces';
 
-/**
- * A routing algorithm that uses the record key
- * with some optional transformations
-*/
-export class KeyRouter implements I.Router {
-    readonly kind = I.RouterKind.STORAGE;
-    readonly transformKey: (key: string) => string;
-
-    constructor(config: KeyRouterConfig) {
-        const extractionFn = extraction(config);
-        const caseFn = caseTransforms(config.case);
-
-        this.transformKey = (key) => caseFn(extractionFn(key));
-    }
-
-    lookup(record: DataEntity): string {
-        return this.transformKey(String(record.getKey()));
-    }
-}
+const logger = debugLogger('key_router');
 
 export enum KeyRouterCaseOptions {
     preserve = 'preserve',
@@ -77,65 +59,100 @@ export interface KeyRouterConfig {
 
 }
 
-function extraction(config: KeyRouterConfig): (key: string) => string {
-    // set suffix defaults
-    const suffixUpper = config.suffix_upper ?? '';
-    const suffixLower = config.suffix_lower ?? '';
-    const suffixOther = config.suffix_other ?? '';
-    const suffixNumber = config.suffix_number ?? '';
-    const suffixUse = config.suffix_use ?? false;
+/**
+ * A routing algorithm that uses the record key
+ * with some optional transformations
+*/
+export class KeyRouter implements I.Router {
+    readonly kind = I.RouterKind.STORAGE;
+    readonly transformKey: (key: string) => string;
+    readonly config: KeyRouterConfig;
+    suffixSize: number;
+    constructor(config: KeyRouterConfig) {
+        this.config = config;
+        // set defaults for suffix
+        this.config.suffix_upper = config.suffix_upper ?? '';
+        this.config.suffix_lower = config.suffix_lower ?? '';
+        this.config.suffix_other = config.suffix_other ?? '';
+        this.config.suffix_number = config.suffix_number ?? '';
+        this.config.suffix_use = config.suffix_use ?? false;
+        this.suffixSize = 0;
+        if (this.config.use != null) {
+            if (this.config.use > 1 && this.config.suffix_use) {
+                logger.warn('KeyRouter may clobber keys when changing case with more than one routing key');
+            }
+            if (this.config.suffix_use
+                && this.config.suffix_upper === ''
+                && this.config.suffix_lower === ''
+                && this.config.suffix_other === ''
+                && this.config.suffix_number === '') {
+                throw new Error('KeyRouter requires that at least one suffix_(upper/lower/other/number) value be specified');
+            }
+        }
 
-    if (config.use != null) {
-        if (config.use === 0) {
-            throw new RangeError('KeyRouter requires that at least one character is selected, use must be greater than 0');
-        }
-        if (config.use > 1 && config.case !== 'preserve' && suffixUse) {
-            throw new RangeError('KeyRouter may clobber keys when changing case with more than one routing key');
-        }
-        if (config.use > 1 && config.case === 'preserve' && suffixUse) {
-            throw new RangeError('KeyRouter with suffix_use:true only works with use:1');
+        const extractionFn = this.extraction();
+        const caseFn = this.caseTransforms(this.config.case);
+        // TODO with this order the suffix will be incorrect because the case gets coverted
+        // first, losing the original value of the routing key
+        // this.transformKey = (key) => this.addSuffix(caseFn((extractionFn(key))));
+
+        // TODO The ordrer case function converts the suffix to uppercase when using case upper
+        this.transformKey = (key) => caseFn(this.addSuffix((extractionFn(key))));
+    }
+
+    lookup(record: DataEntity): string {
+        return this.transformKey(String(record.getKey()));
+    }
+
+    private extraction(): (key: string) => string {
+        if (this.config.use != null) {
+            if (this.config.use === 0) {
+                throw new RangeError('KeyRouter requires that at least one character is selected, use must be greater than 0');
+            }
+
+            if (this.config.from === KeyRouterFromOptions.end) {
+                const start = -Math.abs(this.config.use);
+                return (key) => key.slice(start);
+            }
+
+            const end = this.config.use;
+
+            return (key) => key.slice(0, end);
         }
 
-        if (config.from === KeyRouterFromOptions.end) {
-            const start = -Math.abs(config.use);
-            return (key) => key.slice(start);
+        return (key) => key;
+    }
+
+    private caseTransforms(caseOption = KeyRouterCaseOptions.preserve): (key: string) => string {
+        if (caseOption === KeyRouterCaseOptions.lower) {
+            return (key) => key.toLowerCase();
         }
 
-        const end = config.use;
+        if (caseOption === KeyRouterCaseOptions.upper) {
+            return (key) => key.toUpperCase();
+        }
+
+        return (key) => key;
+    }
+
+    private addSuffix(key: string): string {
         /* Append a suffix to the routing key as defined suffix_upper, suffix_lower,
          * suffix_number, and suffix_other when suffix_use is true
-        */
-        if (end === 1 && suffixUse) {
-            return (key) => {
-                const val = key.slice(0, end);
-                let routingKey: string;
-                if (/[A-Z]/.test(val)) {
-                    routingKey = suffixUse ? `${val.toLowerCase()}${suffixUpper}` : val;
-                } else if (/[a-z]/.test(val)) {
-                    routingKey = suffixUse ? `${val}${suffixLower}` : val;
-                } else if (/[0-9]/.test(val)) {
-                    routingKey = suffixUse ? `${val}${suffixNumber}` : val;
-                } else {
-                    routingKey = suffixUse ? `${val}${suffixOther}` : val;
-                }
-                return routingKey;
-            };
+         */
+
+        if (this.config.use === 1 && this.config.suffix_use) {
+            let routingKey: string;
+            if (/[A-Z]/.test(key)) {
+                routingKey = `${key}${this.config.suffix_upper}`;
+            } else if (/[a-z]/.test(key)) {
+                routingKey = `${key}${this.config.suffix_lower}`;
+            } else if (/[0-9]/.test(key)) {
+                routingKey = `${key}${this.config.suffix_number}`;
+            } else {
+                routingKey = `${key}${this.config.suffix_other}`;
+            }
+            return routingKey;
         }
-
-        return (key) => key.slice(0, end);
+        return key;
     }
-
-    return (key) => key;
-}
-
-function caseTransforms(caseOption = KeyRouterCaseOptions.preserve): (key: string) => string {
-    if (caseOption === KeyRouterCaseOptions.lower) {
-        return (key) => key.toLowerCase();
-    }
-
-    if (caseOption === KeyRouterCaseOptions.upper) {
-        return (key) => key.toUpperCase();
-    }
-
-    return (key) => key;
 }

--- a/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
+++ b/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
@@ -90,6 +90,98 @@ describe('KeyRouter', () => {
         expect(router.lookup(entity)).toEqual('FOO');
     });
 
+    it('should work with use 1 from the beginning and setting suffix for uppercase character', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.preserve,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_upper: '--u'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('r--u');
+    });
+
+    it('should work with use 1 from the beginning and not setting suffix for lowercase', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.preserve,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_upper: '--u'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('bm90Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('b');
+    });
+
+    it('should work with use 1 from the beginning and setting suffix for lowercase', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.preserve,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_upper: '--u',
+            suffix_lower: '--l'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('bm90Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('b--l');
+    });
+
+    it('should work with use 1 from the beginning and setting suffix for other', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.preserve,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_other: '--c'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('_m90Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('_--c');
+    });
+
+    it('should work with use 1 from the beginning and setting suffix for number', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.preserve,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_number: '--n'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('0m90Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('0--n');
+    });
+
+    it('should work with use 1 from the beginning and setting suffix for number', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.preserve,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: false,
+            suffix_number: '--n'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('0m90Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('0');
+    });
+
+
     it('should throw if given use of 0', () => {
         expect(() => {
             new KeyRouter({
@@ -97,4 +189,36 @@ describe('KeyRouter', () => {
             });
         }).toThrow('KeyRouter requires that at least one character is selected, use must be greater than 0');
     });
+
+    it('should throw if given use greater than 1, not preserve case, and use suffix', () => {
+        expect(() => {
+            new KeyRouter({
+                use: 3,
+                suffix_use: true,
+                suffix_upper: '--u',
+                case: KeyRouterCaseOptions.lower
+            });
+        }).toThrow('KeyRouter may clobber keys when changing case with more than one routing key');
+    });
+    it('should throw if given use greater than 1, not preserve case, and use suffix', () => {
+        expect(() => {
+            new KeyRouter({
+                use: 3,
+                suffix_use: true,
+                suffix_upper: '--u',
+                case: KeyRouterCaseOptions.upper
+            });
+        }).toThrow('KeyRouter may clobber keys when changing case with more than one routing key');
+    });
+    it('should throw if given use greater than 1, not preserve case, and use suffix', () => {
+        expect(() => {
+            new KeyRouter({
+                use: 3,
+                suffix_use: true,
+                suffix_upper: '--u',
+                case: KeyRouterCaseOptions.preserve
+            });
+        }).toThrow('KeyRouter with suffix_use:true only works with use:1');
+    });
+
 });

--- a/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
+++ b/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
@@ -92,7 +92,7 @@ describe('KeyRouter', () => {
 
     it('should work with use 1 from the beginning and setting suffix for uppercase character', () => {
         const router = new KeyRouter({
-            case: KeyRouterCaseOptions.preserve,
+            case: KeyRouterCaseOptions.lower,
             use: 1,
             from: KeyRouterFromOptions.beginning,
             suffix_use: true,
@@ -101,17 +101,33 @@ describe('KeyRouter', () => {
 
         const entity = new DataEntity({ foo: 'bar' });
         entity.setKey('Rm9vQmFy');
-
+        expect(entity.getKey()).toEqual('Rm9vQmFy');
         expect(router.lookup(entity)).toEqual('r--u');
     });
 
-    it('should work with use 1 from the beginning and not setting suffix for lowercase', () => {
+    it('should work with use 1 from the beginning and setting suffix for uppercase character and case upper', () => {
         const router = new KeyRouter({
-            case: KeyRouterCaseOptions.preserve,
+            case: KeyRouterCaseOptions.upper,
             use: 1,
             from: KeyRouterFromOptions.beginning,
             suffix_use: true,
             suffix_upper: '--u'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('Rm9vQmFy');
+        expect(entity.getKey()).toEqual('Rm9vQmFy');
+        expect(router.lookup(entity)).toEqual('R--u');
+    });
+
+    it('should work with use 1 from the beginning and not setting suffix for lowercase', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.lower,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_upper: '--u',
+            suffix_lower: ''
         });
 
         const entity = new DataEntity({ foo: 'bar' });
@@ -120,9 +136,25 @@ describe('KeyRouter', () => {
         expect(router.lookup(entity)).toEqual('b');
     });
 
-    it('should work with use 1 from the beginning and setting suffix for lowercase', () => {
+    it('should not append suffix with use 3 from the beginning and not setting suffix for lowercase', () => {
         const router = new KeyRouter({
             case: KeyRouterCaseOptions.preserve,
+            use: 3,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_upper: '--u',
+            suffix_lower: '--l'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('bM90Rm9vQmFy');
+
+        expect(router.lookup(entity)).toEqual('bM9');
+    });
+
+    it('should work with use 1 from the beginning and setting suffix for lowercase', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.lower,
             use: 1,
             from: KeyRouterFromOptions.beginning,
             suffix_use: true,
@@ -181,6 +213,48 @@ describe('KeyRouter', () => {
         expect(router.lookup(entity)).toEqual('0');
     });
 
+    it('should work with use 1 from the end and setting suffix true', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.lower,
+            use: 1,
+            from: KeyRouterFromOptions.end,
+            suffix_use: true,
+            suffix_upper: '--u'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('0m90Rm9vQmFY');
+
+        expect(router.lookup(entity)).toEqual('y--u');
+    });
+
+    it('should work with use 1 from the beginning and setting suffix for all characters', () => {
+        const router = new KeyRouter({
+            case: KeyRouterCaseOptions.lower,
+            use: 1,
+            from: KeyRouterFromOptions.beginning,
+            suffix_use: true,
+            suffix_upper: '--u',
+            suffix_lower: '--l',
+            suffix_number: '--n',
+            suffix_other: '--c'
+        });
+
+        const entity = new DataEntity({ foo: 'bar' });
+        entity.setKey('Rm9vQmFy');
+        expect(entity.getKey()).toEqual('Rm9vQmFy');
+        expect(router.lookup(entity)).toEqual('r--u');
+        entity.setKey('rm9vQmFy');
+        expect(entity.getKey()).toEqual('rm9vQmFy');
+        expect(router.lookup(entity)).toEqual('r--l');
+        entity.setKey('0m9vQmFy');
+        expect(entity.getKey()).toEqual('0m9vQmFy');
+        expect(router.lookup(entity)).toEqual('0--n');
+        entity.setKey('_m9vQmFy');
+        expect(entity.getKey()).toEqual('_m9vQmFy');
+        expect(router.lookup(entity)).toEqual('_--c');
+    });
+
     it('should throw if given use of 0', () => {
         expect(() => {
             new KeyRouter({
@@ -189,34 +263,14 @@ describe('KeyRouter', () => {
         }).toThrow('KeyRouter requires that at least one character is selected, use must be greater than 0');
     });
 
-    it('should throw if given use greater than 1, lower case, and use suffix', () => {
+    it('should throw if given suffix_use true and not defined suffix', () => {
         expect(() => {
             new KeyRouter({
-                use: 3,
+                case: KeyRouterCaseOptions.lower,
+                use: 1,
+                from: KeyRouterFromOptions.beginning,
                 suffix_use: true,
-                suffix_upper: '--u',
-                case: KeyRouterCaseOptions.lower
             });
-        }).toThrow('KeyRouter may clobber keys when changing case with more than one routing key');
-    });
-    it('should throw if given use greater than 1, upper case, and use suffix', () => {
-        expect(() => {
-            new KeyRouter({
-                use: 3,
-                suffix_use: true,
-                suffix_upper: '--u',
-                case: KeyRouterCaseOptions.upper
-            });
-        }).toThrow('KeyRouter may clobber keys when changing case with more than one routing key');
-    });
-    it('should throw if given use greater than 1, not preserve case, and use suffix', () => {
-        expect(() => {
-            new KeyRouter({
-                use: 3,
-                suffix_use: true,
-                suffix_upper: '--u',
-                case: KeyRouterCaseOptions.preserve
-            });
-        }).toThrow('KeyRouter with suffix_use:true only works with use:1');
+        }).toThrow('KeyRouter requires that at least one suffix_(upper/lower/other/number) value be specified');
     });
 });

--- a/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
+++ b/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
@@ -166,7 +166,7 @@ describe('KeyRouter', () => {
         expect(router.lookup(entity)).toEqual('0--n');
     });
 
-    it('should work with use 1 from the beginning and setting suffix for number', () => {
+    it('should work with use 1 from the beginning and setting suffix false for number', () => {
         const router = new KeyRouter({
             case: KeyRouterCaseOptions.preserve,
             use: 1,
@@ -181,7 +181,6 @@ describe('KeyRouter', () => {
         expect(router.lookup(entity)).toEqual('0');
     });
 
-
     it('should throw if given use of 0', () => {
         expect(() => {
             new KeyRouter({
@@ -190,7 +189,7 @@ describe('KeyRouter', () => {
         }).toThrow('KeyRouter requires that at least one character is selected, use must be greater than 0');
     });
 
-    it('should throw if given use greater than 1, not preserve case, and use suffix', () => {
+    it('should throw if given use greater than 1, lower case, and use suffix', () => {
         expect(() => {
             new KeyRouter({
                 use: 3,
@@ -200,7 +199,7 @@ describe('KeyRouter', () => {
             });
         }).toThrow('KeyRouter may clobber keys when changing case with more than one routing key');
     });
-    it('should throw if given use greater than 1, not preserve case, and use suffix', () => {
+    it('should throw if given use greater than 1, upper case, and use suffix', () => {
         expect(() => {
             new KeyRouter({
                 use: 3,
@@ -220,5 +219,4 @@ describe('KeyRouter', () => {
             });
         }).toThrow('KeyRouter with suffix_use:true only works with use:1');
     });
-
 });

--- a/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
+++ b/packages/standard-asset-apis/test/routers/KeyRouter-spec.ts
@@ -117,7 +117,7 @@ describe('KeyRouter', () => {
         const entity = new DataEntity({ foo: 'bar' });
         entity.setKey('Rm9vQmFy');
         expect(entity.getKey()).toEqual('Rm9vQmFy');
-        expect(router.lookup(entity)).toEqual('R--u');
+        expect(router.lookup(entity)).toEqual('R--U');
     });
 
     it('should work with use 1 from the beginning and not setting suffix for lowercase', () => {


### PR DESCRIPTION
- Added option `suffix_use` to append a suffix to the routing key
- Added optional suffix values for `suffix_upper`, `suffix_lower`, `suffix_number`, and `suffix_other`
- Example to only append a suffix for uppercase routing keys
```json
{
  "_op": "key_router",
  "use": 1
  "from": "beginning",
  "suffix_use": true,
  "suffix_upper": "--u",
} 
```
- Example to only append suffixes for all routing keys
```json
{
  "_op": "key_router",
  "use": 1
  "from": "beginning",
  "suffix_use": true,
  "suffix_upper": "--u",
  "suffix_lower": "--l",
  "suffix_number": "--n",
  "suffix_other":  "--c"
} 
```

refs #373 