### PR TITLE
Upgrade ts-transforms, utils, job-components, etc.

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -20,16 +20,16 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@terascope/job-components": "^0.59.0",
+        "@terascope/job-components": "^0.64.0",
         "@terascope/standard-asset-apis": "^0.6.1",
-        "@terascope/utils": "^0.46.0",
+        "@terascope/utils": "^0.51.0",
         "@types/express": "^4.17.17",
         "express": "^4.18.2",
         "mocker-data-generator": "^2.12.0",
         "prom-client": "^14.2.0",
         "short-unique-id": "^5.0.3",
         "timsort": "^0.3.0",
-        "ts-transforms": "^0.71.0"
+        "ts-transforms": "^0.76.0"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^0.7.1",
-        "@terascope/job-components": "^0.59.0",
-        "@terascope/scripts": "0.58.0",
+        "@terascope/job-components": "^0.64.0",
+        "@terascope/scripts": "0.59.0",
         "@terascope/standard-asset-apis": "^0.6.1",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.5",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "^2.0.1",
-        "@terascope/utils": "^0.46.0"
+        "@terascope/utils": "^0.51.0"
     },
     "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,14 +676,14 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@terascope/data-mate@^0.42.0":
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.42.0.tgz#40ab7460436e9f3663784d96c8a77da24ee28f9a"
-  integrity sha512-ipdMVGK1+8RgUUXooUWA2b1thzgCV6JjQXUnkiAz8LO+VUqKBLR/9aqGbXDH3N4J/hWPTn0ctvcDYhv7VgDYhQ==
+"@terascope/data-mate@^0.47.0":
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.47.0.tgz#b6c58799c8960912ccb72d5ee756560859edb635"
+  integrity sha512-q+4q4BG1aNRi/GXvLFpBGEqSRnNDyITdeS+4FoM1fZyro+Xu5E14ziZUCdlbFjo+qPSc7vyc6+09341X5kTWfA==
   dependencies:
-    "@terascope/data-types" "^0.37.0"
+    "@terascope/data-types" "^0.42.0"
     "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.46.0"
+    "@terascope/utils" "^0.51.0"
     "@types/validator" "^13.7.17"
     awesome-phonenumber "^2.70.0"
     date-fns "^2.30.0"
@@ -698,15 +698,15 @@
     uuid "^9.0.0"
     valid-url "^1.0.9"
     validator "^13.9.0"
-    xlucene-parser "^0.45.0"
+    xlucene-parser "^0.50.0"
 
-"@terascope/data-types@^0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.37.0.tgz#6718cfd6e705d108ce1c1681558e3c5679886886"
-  integrity sha512-nZFma3skhxxR15Zje1GH6/OBjT01yg2LfRTfRPoJZK/rEuqXqw0Fvn4s8n7SIvCGg3kj/7tpiJwsBB+XvGy4ag==
+"@terascope/data-types@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.42.0.tgz#13bbb7739ff8b1352f98730f1829f5b61bd34933"
+  integrity sha512-EC+PObGY4d/gCN8NCOWbccctSQ3ZBMKIHzIMh7JJt4/HKjgxDNxvakOZU+V0janmPzw11Q4DziIxmvkNf5rqXg==
   dependencies:
     "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.46.0"
+    "@terascope/utils" "^0.51.0"
     graphql "^14.7.0"
     lodash "^4.17.21"
     yargs "^17.7.2"
@@ -738,24 +738,24 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.59.0":
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.59.0.tgz#f09b1c81f388beee822064a67427bc259a534b47"
-  integrity sha512-0bfLAzlQoWZEtKiymIhp9duEM8JGKWF7LXyoU67N1nQehs8PJ/quWuBYfCEcr9Oa0d4ba458u5gRTBefxRRdeg==
+"@terascope/job-components@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.64.0.tgz#667522ffec485ca71e4037b902a1c0a0924c2243"
+  integrity sha512-ScxcgNt+kvsrlOm8FhnmqpAvj5ozowiuDMenrk1zvBytkwc7gl20WQqWDQs6ilLSkBB3I9T4YT4laGwQbtoYNg==
   dependencies:
-    "@terascope/utils" "^0.46.0"
+    "@terascope/utils" "^0.51.0"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
     datemath-parser "^1.0.6"
     uuid "^9.0.0"
 
-"@terascope/scripts@0.58.0":
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.58.0.tgz#cd6d941ea8f62afa0ecc0e07fe0471fbf48e4da8"
-  integrity sha512-TM4iv0vafBVSSsu35lccfjIzm7sfqG2NaLzFWprFV63SvAdkBiktvHWrIaGXPucKIjuA3wdOVzf/qWwrgN/VGA==
+"@terascope/scripts@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.59.0.tgz#bec8491358e1e4365682041bf98fb43a51dd192c"
+  integrity sha512-NRb3TYFleFAhXvb0kn3rrZIvl3WupFJn/X4IV+xtrmI3IgL/oCLmI+bjru6W5Wg1LwuyhJ4qbcKGfQZkKzK9gQ==
   dependencies:
-    "@terascope/utils" "^0.50.0"
+    "@terascope/utils" "^0.51.0"
     codecov "^3.8.3"
     execa "^5.1.0"
     fs-extra "^10.1.0"
@@ -789,51 +789,10 @@
   resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.11.2.tgz#8439b04ba4c5d8357d00a7e20a831f4864ae4c81"
   integrity sha512-oWrKZYm5HsZc2bCxirPnnYD6yu5wW74W7OTKD7Vm38KI/8TcfZPlr/U+gBwocQGVJrBM9jg0+jcjaxudLjfXiw==
 
-"@terascope/utils@^0.46.0":
-  version "0.46.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.46.0.tgz#949ecbad7a1f678ad84861a6cde45d812f29dade"
-  integrity sha512-shgYj0I57nZ2sT0v5zoQwD+KnHSFXn1quYrGGzH2RAdl2UFz9fibfkVC4nM+bmkT9ptuzEBjyqEXnD/L027jdQ==
-  dependencies:
-    "@terascope/types" "^0.11.2"
-    "@turf/bbox" "^6.4.0"
-    "@turf/bbox-polygon" "^6.4.0"
-    "@turf/boolean-contains" "^6.4.0"
-    "@turf/boolean-disjoint" "^6.4.0"
-    "@turf/boolean-equal" "^6.4.0"
-    "@turf/boolean-intersects" "^6.4.0"
-    "@turf/boolean-point-in-polygon" "^6.4.0"
-    "@turf/boolean-within" "^6.4.0"
-    "@turf/circle" "^6.4.0"
-    "@turf/helpers" "^6.2.0"
-    "@turf/invariant" "^6.2.0"
-    "@turf/line-to-polygon" "^6.4.0"
-    "@types/lodash" "^4.14.195"
-    "@types/validator" "^13.7.17"
-    awesome-phonenumber "^2.70.0"
-    date-fns "^2.30.0"
-    date-fns-tz "^1.3.7"
-    datemath-parser "^1.0.6"
-    debug "^4.3.4"
-    geo-tz "^7.0.7"
-    ip-bigint "^3.0.3"
-    ip6addr "^0.2.5"
-    ipaddr.js "^2.0.1"
-    is-cidr "^4.0.2"
-    is-ip "^3.1.0"
-    is-plain-object "^5.0.0"
-    js-string-escape "^1.0.1"
-    kind-of "^6.0.3"
-    latlon-geohash "^1.1.0"
-    lodash "^4.17.21"
-    mnemonist "^0.39.5"
-    p-map "^4.0.0"
-    shallow-clone "^3.0.1"
-    validator "^13.9.0"
-
-"@terascope/utils@^0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.50.0.tgz#dd45b4ff03632756a0a135041c02a44e0ae27c7d"
-  integrity sha512-+FqiwTaDso1EqtLmvB7u+YdPnvpcW9CwKbbpGqRramssV4JG+Euw5tJgcwt4sObPv6xSbCzEyUoASARU85jSNg==
+"@terascope/utils@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.51.0.tgz#ff48164dd4e3afa501517fdaac4fa2ac1f4a5323"
+  integrity sha512-PneoBPGLZJvsRU8edQG0IISzNj3aKB1SZc2wPJW2jn30cGEyU+lltebDYtS2A204c98duslRD4u7npb6byecAw==
   dependencies:
     "@terascope/types" "^0.11.2"
     "@turf/bbox" "^6.4.0"
@@ -4702,11 +4661,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-netmask@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
-  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
-
 node-fetch@^2.6.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
@@ -5891,14 +5845,14 @@ ts-jest@^29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-ts-transforms@^0.71.0:
-  version "0.71.0"
-  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.71.0.tgz#5272f08f12ed04c31275b5137db024f078d04429"
-  integrity sha512-R1L+HdGl0sqkHV2SQOQSxtMMbdOzJkuyDpxLa38uYNdaGTVPWF0EDUjXroaQ164TNypYbmJzEjhQsiFZlfIbFA==
+ts-transforms@^0.76.0:
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.76.0.tgz#1bf0ffc40e1908e426f7d378920e37446085f02e"
+  integrity sha512-RwYR3tR0eaz7H89iueIECwNnIuik1A1iBHx1STf+bpK1TrY9Y3nCn/zbqjMPf9Uctr4uMH96+z9wfl3yOEtClw==
   dependencies:
-    "@terascope/data-mate" "^0.42.0"
+    "@terascope/data-mate" "^0.47.0"
     "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.46.0"
+    "@terascope/utils" "^0.51.0"
     awesome-phonenumber "^2.70.0"
     graphlib "^2.1.8"
     is-ip "^3.1.0"
@@ -6230,14 +6184,13 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-xlucene-parser@^0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.45.0.tgz#7debd89666628f5ec80cdde45d478e3d185fc039"
-  integrity sha512-1FECtVkrR4VMKNTTgnkJohWI0eYR4xsNu9wwPJ0zB1kzSZPe6RyydsatMjHYYSSOzZnBYZ0woQ8KFXWZSnoRkg==
+xlucene-parser@^0.50.0:
+  version "0.50.0"
+  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.50.0.tgz#1f4125545d87c36bf2bf2c7eef792fbcecb88577"
+  integrity sha512-v76Bghn30pzkTqS3l8wrS1wdXywmZ3kMZ4XNZHqQpYQAtsD3EaG4O8K7r7vmWcTzXy1sP+Cm47ylsWWFMWuJqw==
   dependencies:
     "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.46.0"
-    netmask "^2.0.2"
+    "@terascope/utils" "^0.51.0"
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
The following packages were upgraded:

- ts-transforms                               0.71.0 => 0.76.0
- @terascope/scripts                     0.58.0 => 0.59.0
- @terascope/utils                          0.46.0 => 0.51.0
- @terascope/job-components    0.59.0 => 0.64.0
