### PR TITLE
Bump mock-data-generator to v3.0.3

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -20,13 +20,17 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
+        "@faker-js/faker": "^8.1.0",
         "@terascope/job-components": "^0.64.0",
         "@terascope/standard-asset-apis": "^0.6.1",
         "@terascope/utils": "^0.51.0",
+        "@types/chance": "^1.1.4",
         "@types/express": "^4.17.17",
+        "chance": "^1.1.11",
         "express": "^4.18.2",
-        "mocker-data-generator": "^2.12.0",
+        "mocker-data-generator": "^3.0.3",
         "prom-client": "^14.2.0",
+        "randexp": "^0.5.3",
         "short-unique-id": "^5.0.3",
         "timsort": "^0.3.0",
         "ts-transforms": "^0.76.0"

--- a/asset/package.json
+++ b/asset/package.json
@@ -34,7 +34,7 @@
         "short-unique-id": "^5.0.3",
         "timsort": "^0.3.0",
         "ts-transforms": "^0.76.0",
-        "tslib": "2.6.2"
+        "tslib": "^2.6.2"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/asset/package.json
+++ b/asset/package.json
@@ -33,7 +33,8 @@
         "randexp": "^0.5.3",
         "short-unique-id": "^5.0.3",
         "timsort": "^0.3.0",
-        "ts-transforms": "^0.76.0"
+        "ts-transforms": "^0.76.0",
+        "tslib": "2.6.2"
     },
     "engines": {
         "node": ">=14.17.0",

--- a/asset/src/data_generator/fetcher.ts
+++ b/asset/src/data_generator/fetcher.ts
@@ -2,11 +2,15 @@ import {
     Fetcher, WorkerContext, ExecutionConfig, TSError, AnyObject
 } from '@terascope/job-components';
 import mocker from 'mocker-data-generator';
+import { faker } from '@faker-js/faker';
+import Randexp from 'randexp';
+import Chance from 'chance';
 import path from 'path';
 import { existsSync } from 'fs';
 import { DataGenerator, CounterResults } from './interfaces';
 import defaultSchema from './data-schema';
 
+const chance = new Chance();
 export default class DataGeneratorFetcher extends Fetcher<DataGenerator> {
     dataSchema: AnyObject;
 
@@ -21,6 +25,9 @@ export default class DataGeneratorFetcher extends Fetcher<DataGenerator> {
 
         if (this.opConfig.stress_test) {
             return mocker()
+                .addGenerator('faker', faker)
+                .addGenerator('chance', chance)
+                .addGenerator('randexp', Randexp, (Generator, input) => new Generator(input).gen())
                 .schema('schema', this.dataSchema, 1)
                 .build()
                 .then((dataObj) => {
@@ -35,6 +42,9 @@ export default class DataGeneratorFetcher extends Fetcher<DataGenerator> {
         }
 
         return mocker()
+            .addGenerator('faker', faker)
+            .addGenerator('chance', chance)
+            .addGenerator('randexp', Randexp, (Generator, input) => new Generator(input).gen())
             .schema('schema', this.dataSchema, count)
             .build()
             .then((dataObj) => dataObj.schema)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "node-notifier": "^10.0.1",
         "teraslice-test-harness": "^0.29.0",
         "ts-jest": "^29.1.1",
-        "tslib": "^2.6.1",
+        "tslib": "2.6.2",
         "typescript": "^4.8.3"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "node-notifier": "^10.0.1",
         "teraslice-test-harness": "^0.29.0",
         "ts-jest": "^29.1.1",
-        "tslib": "2.6.2",
+        "tslib": "^2.6.2",
         "typescript": "^4.8.3"
     },
     "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5858,15 +5858,15 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,6 +355,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.50.0.tgz#9e93b850f0f3fa35f5fa59adfd03adae8488e484"
   integrity sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==
 
+"@faker-js/faker@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.1.0.tgz#e14896f1c57af2495e341dc4c7bf04125c8aeafd"
+  integrity sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==
+
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"
@@ -1057,6 +1062,11 @@
     "@types/keyv" "^3.1.4"
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
+
+"@types/chance@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.4.tgz#bdb4f5b36ed7622640b597720e8affbfaa7bbfd7"
+  integrity sha512-et3alUWI9jEPnGai+QRCyDdRMYS+atq32IaldWURyxPRZBYg+cSwppxK2UHnDv9X/0pdoxR3Ufbz5hRmjD/uNg==
 
 "@types/connect@*":
   version "3.4.36"
@@ -1838,14 +1848,6 @@ caniuse-lite@^1.0.30001449:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz#8b3fad73dc35b2674a5c96df2d4f9f1c561435de"
   integrity sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==
 
-casual-browserify@^1.5.19:
-  version "1.5.19"
-  resolved "https://registry.yarnpkg.com/casual-browserify/-/casual-browserify-1.5.19.tgz#5c40025225d543bfeb9e19f99f453b08cd0578e1"
-  integrity sha512-j3xhfvYQRWxxaYDr2jMwH4xBuTd9u3ZVsPR59PYJ8MX1TX4Aw1TipxZ1r1iYDmhauqBj1AmvH6vQcku2GvQhpQ==
-  dependencies:
-    mersenne-twister "^1.0.1"
-    moment "^2.15.2"
-
 chalk@^2.0.0, chalk@^2.3.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1863,7 +1865,7 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chance@^1.1.7:
+chance@^1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.11.tgz#78e10e1f9220a5bbc60a83e3f28a5d8558d84d1b"
   integrity sha512-kqTg3WWywappJPqtgrdvbA380VoXO2eu9VCV895JgbyHsaErXdyHK9LOZ911OvAk6L0obK7kDk9CGs8+oBawVA==
@@ -2772,11 +2774,6 @@ extsprintf@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
-faker@^5.3.1:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -4524,11 +4521,6 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mersenne-twister@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
-  integrity sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==
-
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -4600,18 +4592,12 @@ mnemonist@^0.39.5:
   dependencies:
     obliterator "^2.0.1"
 
-mocker-data-generator@^2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/mocker-data-generator/-/mocker-data-generator-2.12.0.tgz#12618f095371f6167bbec234a71fbc8f2755e9e9"
-  integrity sha512-TE+JYb46On9xzTruZEO0Y1sgowE7C/fM4X+lWuBpCztDv9AjSnztnuAkcAgf+nH45DtT4Z9viLehhtXCps8wvA==
-  dependencies:
-    casual-browserify "^1.5.19"
-    chance "^1.1.7"
-    faker "^5.3.1"
-    randexp "^0.5.3"
-    tslib "^2.1.0"
+mocker-data-generator@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/mocker-data-generator/-/mocker-data-generator-3.0.3.tgz#898323f042404d60a56c036919ce65533cf9e078"
+  integrity sha512-QQDEq/EXPh4MLLbEz9G2qQjZzrB19J98cIqQBcZ5sknLdjOjgs7xenxShv70wTjpryPtoy8+Q0012uPmmflCog==
 
-moment@^2.15.2, moment@^2.22.2, moment@^2.29.1:
+moment@^2.22.2, moment@^2.29.1:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -5876,11 +5862,6 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.1.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@^2.6.1:
   version "2.6.2"


### PR DESCRIPTION
I've updated the dependency ```mock-data-generator``` to ```v3.0.3``` from ```v2.12.0```

Here are dependencies that got added to the assets package.json to be compatible with the new major version of mock-data-generator.
- ```@faker-js/faker@v8.1.0```
- ```@types/chance@v1.1.4```
- ```chance@v1.1.11```
- ```randexp@0.5.3```

The reason is because mock-data-generator now has you bring in your own 3rd party generators instead of having them built in. So I had to install all the generators that we were utilizing previously and use the new ```addGenerator()``` method to the ```mocker()``` function to get it to work correctly. 

Diff[ Link](https://github.com/terascope/standard-assets/compare/master...update-data-generator#diff-5f4dc783289d20bf2647fe9e38f18d9a8828050fa2e563bd990fef8ed145c834)
File: ```standard-assets/asset/src/data_generator/fetcher.ts```
```typescript
22:     async fetch(slice?: CounterResults): Promise<AnyObject[]> {
23:         if (slice == null) return [];
24:         const { count } = slice;
25: 
26:         if (this.opConfig.stress_test) {
27:             return mocker()
-> 28:                 .addGenerator('faker', faker)
-> 29:                 .addGenerator('chance', chance)
-> 30:                 .addGenerator('randexp', Randexp, (Generator, input) => new Generator(input).gen())
31:                 .schema('schema', this.dataSchema, 1)
32:                 .build()
33:                 .then((dataObj) => {
34:                     const results = [];
35:                     const data = dataObj.schema[0];
36:                     for (let i = 0; i < count; i += 1) {
37:                         results.push(data);
38:                     }
39:                     return results;
40:                 })
41:                 .catch((err) => Promise.reject(new TSError(err, { reason: 'could not generate mocked data' })));
42:         }
43: 
44:         return mocker()
-> 45:             .addGenerator('faker', faker)
-> 46:             .addGenerator('chance', chance)
-> 47:             .addGenerator('randexp', Randexp, (Generator, input) => new Generator(input).gen())
48:             .schema('schema', this.dataSchema, count)
49:             .build()
50:             .then((dataObj) => dataObj.schema)
51:             .catch((err) => Promise.reject(new TSError(err, { reason: 'could not generate mocked data' })));
52:     }
```