### PR TITLE
Dependency updates, 2023-12-11

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -21,9 +21,9 @@
     },
     "dependencies": {
         "@faker-js/faker": "^8.3.1",
-        "@terascope/job-components": "^0.64.0",
+        "@terascope/job-components": "^0.65.0",
         "@terascope/standard-asset-apis": "^0.6.2",
-        "@terascope/utils": "^0.51.0",
+        "@terascope/utils": "^0.52.0",
         "@types/chance": "^1.1.4",
         "@types/express": "^4.17.19",
         "chance": "^1.1.11",
@@ -33,7 +33,7 @@
         "randexp": "^0.5.3",
         "short-unique-id": "^5.0.3",
         "timsort": "^0.3.0",
-        "ts-transforms": "^0.77.0",
+        "ts-transforms": "^0.78.0",
         "tslib": "^2.6.2"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/job-components": "^0.64.0",
-        "@terascope/scripts": "0.62.0",
+        "@terascope/job-components": "^0.65.0",
+        "@terascope/scripts": "0.63.0",
         "@terascope/standard-asset-apis": "^0.6.2",
         "@types/express": "^4.17.19",
         "@types/jest": "^29.5.10",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "^2.0.1",
-        "@terascope/utils": "^0.51.0"
+        "@terascope/utils": "^0.52.0"
     },
     "devDependencies": {
         "@types/jest": "^29.5.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,15 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13":
+"@babel/code-frame@^7.12.13":
+  version "7.23.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
+  integrity sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==
+  dependencies:
+    "@babel/highlight" "^7.23.4"
+    chalk "^2.4.2"
+
+"@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
   integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
@@ -193,10 +201,19 @@
     "@babel/traverse" "^7.21.5"
     "@babel/types" "^7.21.5"
 
-"@babel/highlight@^7.18.6", "@babel/highlight@^7.22.13":
+"@babel/highlight@^7.18.6":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
   integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.22.13", "@babel/highlight@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
+  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
   dependencies:
     "@babel/helper-validator-identifier" "^7.22.20"
     chalk "^2.4.2"
@@ -761,14 +778,14 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@terascope/data-mate@^0.48.0":
-  version "0.48.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.48.0.tgz#1c012f92b040c43d1575f35dddff92bffca5cf2e"
-  integrity sha512-4Q0etVDdDyojPqzbtuBKFH1IeetGHachKs+u3jCOlCZmn/jXkiyxT2OE2KQPzINr+/l07soNjl4fzsc3hftpYA==
+"@terascope/data-mate@^0.49.0":
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.49.0.tgz#62217f46c70f6d2adfe6f040482f7f8be08c8b5f"
+  integrity sha512-nzEsY+60uKZC2BSQyyDBUZlGETK67lZOKXjoIS/g8pzWvA8p6WKJFowwi2ihZMqPgcGa+4tcoQnnUM/m5EGs7g==
   dependencies:
-    "@terascope/data-types" "^0.42.0"
-    "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.51.0"
+    "@terascope/data-types" "^0.43.0"
+    "@terascope/types" "^0.12.0"
+    "@terascope/utils" "^0.52.0"
     "@types/validator" "^13.7.17"
     awesome-phonenumber "^2.70.0"
     date-fns "^2.30.0"
@@ -783,15 +800,15 @@
     uuid "^9.0.0"
     valid-url "^1.0.9"
     validator "^13.9.0"
-    xlucene-parser "^0.50.0"
+    xlucene-parser "^0.51.0"
 
-"@terascope/data-types@^0.42.0":
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.42.0.tgz#13bbb7739ff8b1352f98730f1829f5b61bd34933"
-  integrity sha512-EC+PObGY4d/gCN8NCOWbccctSQ3ZBMKIHzIMh7JJt4/HKjgxDNxvakOZU+V0janmPzw11Q4DziIxmvkNf5rqXg==
+"@terascope/data-types@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.43.0.tgz#277593cea86152a5db5098cb0b0d94ee96762983"
+  integrity sha512-zqj2l4fObOWpoovvHryz0UJE5HWA5hqkIF1qghbIeUvIh6qtu2Hv3ZbS+5ESXRXJ8I8E2UNm10f7mtGwr0dyAg==
   dependencies:
-    "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.51.0"
+    "@terascope/types" "^0.12.0"
+    "@terascope/utils" "^0.52.0"
     graphql "^14.7.0"
     lodash "^4.17.21"
     yargs "^17.7.2"
@@ -823,25 +840,25 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.64.0":
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.64.0.tgz#667522ffec485ca71e4037b902a1c0a0924c2243"
-  integrity sha512-ScxcgNt+kvsrlOm8FhnmqpAvj5ozowiuDMenrk1zvBytkwc7gl20WQqWDQs6ilLSkBB3I9T4YT4laGwQbtoYNg==
+"@terascope/job-components@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.65.0.tgz#fc9d6685244c97938fa5a8322da80ea3485783dd"
+  integrity sha512-aL+gqLT670bSfz0X5XqTZI7evw7RAtyOOHt0iDcXdw1UeQfEAUe1wlO3Zfa/z91EYyuDfyJawM12XGAkgvXhLA==
   dependencies:
-    "@terascope/utils" "^0.51.0"
+    "@terascope/utils" "^0.52.0"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
     datemath-parser "^1.0.6"
     uuid "^9.0.0"
 
-"@terascope/scripts@0.62.0":
-  version "0.62.0"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.62.0.tgz#be589aea17c0a6ed4e0c48cf8faf8d3f0160ec88"
-  integrity sha512-mDtvRnf7wAYDYB+QzaJ63S3eS4oR/EErh0gaVR8lVC3nyUmh66tXNem8jaQQVu8eBiegGST5v1qWrw/2ZaMJFg==
+"@terascope/scripts@0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.63.0.tgz#8d675b23c39abe8e8475a7b11736fb48b6711a4a"
+  integrity sha512-UYu6XtqMY50Ao9hYcizR+U7ixLAWX1gL0LA0mrJDHar5LbQkxI0+HOgkXktG2MvFGgb59BtqwyQmKpAT63X0Fw==
   dependencies:
     "@kubernetes/client-node" "^0.20.0"
-    "@terascope/utils" "^0.51.0"
+    "@terascope/utils" "^0.52.0"
     codecov "^3.8.3"
     execa "^5.1.0"
     fs-extra "^11.1.1"
@@ -870,17 +887,17 @@
   dependencies:
     bluebird "^3.7.2"
 
-"@terascope/types@^0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.11.2.tgz#8439b04ba4c5d8357d00a7e20a831f4864ae4c81"
-  integrity sha512-oWrKZYm5HsZc2bCxirPnnYD6yu5wW74W7OTKD7Vm38KI/8TcfZPlr/U+gBwocQGVJrBM9jg0+jcjaxudLjfXiw==
+"@terascope/types@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.12.0.tgz#937ae7ae53965a3cb19eccbeac83d64fd00f4f2d"
+  integrity sha512-6jFvN3ESEJ6YzB+S618qRAkQq0I1QCVcDX1Wcm5E1sZTMRIoseG39I3paM+bkawAoOTkG5DqruLXLgg6BIwUtQ==
 
-"@terascope/utils@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.51.0.tgz#ff48164dd4e3afa501517fdaac4fa2ac1f4a5323"
-  integrity sha512-PneoBPGLZJvsRU8edQG0IISzNj3aKB1SZc2wPJW2jn30cGEyU+lltebDYtS2A204c98duslRD4u7npb6byecAw==
+"@terascope/utils@^0.52.0":
+  version "0.52.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.52.0.tgz#b47ea5cc6f8643009b3e7c1ab126fc312399ab68"
+  integrity sha512-SPdMznXvzBGXK8UF2STGFqGR81R9hoV6NOl1821jqyYFmFJq66p3CadyUuHCDvtoK23Qfk63/xUJjLo1m10Dwg==
   dependencies:
-    "@terascope/types" "^0.11.2"
+    "@terascope/types" "^0.12.0"
     "@turf/bbox" "^6.4.0"
     "@turf/bbox-polygon" "^6.4.0"
     "@turf/boolean-contains" "^6.4.0"
@@ -1236,9 +1253,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^29.5.10":
-  version "29.5.10"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.10.tgz#a10fc5bab9e426081c12b2ef73d24d4f0c9b7f50"
-  integrity sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==
+  version "29.5.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.11.tgz#0c13aa0da7d0929f078ab080ae5d4ced80fa2f2c"
+  integrity sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -1300,16 +1317,16 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "20.9.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.0.tgz#bfcdc230583aeb891cf51e73cfdaacdd8deae298"
-  integrity sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==
+  version "20.10.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.4.tgz#b246fd84d55d5b1b71bf51f964bd514409347198"
+  integrity sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==
   dependencies:
     undici-types "~5.26.4"
 
 "@types/node@^18.14.2":
-  version "18.18.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.9.tgz#5527ea1832db3bba8eb8023ce8497b7d3f299592"
-  integrity sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==
+  version "18.19.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.3.tgz#e4723c4cb385641d61b983f6fe0b716abd5f8fc0"
+  integrity sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==
   dependencies:
     undici-types "~5.26.4"
 
@@ -1402,9 +1419,9 @@
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
 "@types/yargs@^17.0.8":
-  version "17.0.31"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.31.tgz#8fd0089803fd55d8a285895a18b88cb71a99683c"
-  integrity sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==
+  version "17.0.32"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.32.tgz#030774723a2f7faafebf645f4e5a48371dca6229"
+  integrity sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -6549,14 +6566,14 @@ ts-jest@^29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-ts-transforms@^0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.77.0.tgz#b7e90ead06c03d692ed17819fb4aea6c9dd725af"
-  integrity sha512-d5SvgH0QkrCA2v1rtFehFRQzh1UVw1RvCYjZuo24lCwUG7VoxWFPub1EM9MLNa0+zutRHBeEu4jpMSQNEj68pg==
+ts-transforms@^0.78.0:
+  version "0.78.0"
+  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.78.0.tgz#7175804d56245b551d48ebb7e3c658c4021c5e62"
+  integrity sha512-AkA5gTJ1Xrfka7vTrQiDHny1bpDMQY0BuaLs0e7ZRIOTin+BVAxmKJpQdg9r9mEfna+ZrMkop7TveR6IzJzZxg==
   dependencies:
-    "@terascope/data-mate" "^0.48.0"
-    "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.51.0"
+    "@terascope/data-mate" "^0.49.0"
+    "@terascope/types" "^0.12.0"
+    "@terascope/utils" "^0.52.0"
     awesome-phonenumber "^2.70.0"
     graphlib "^2.1.8"
     is-ip "^3.1.0"
@@ -6969,13 +6986,13 @@ ws@^8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
-xlucene-parser@^0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.50.0.tgz#1f4125545d87c36bf2bf2c7eef792fbcecb88577"
-  integrity sha512-v76Bghn30pzkTqS3l8wrS1wdXywmZ3kMZ4XNZHqQpYQAtsD3EaG4O8K7r7vmWcTzXy1sP+Cm47ylsWWFMWuJqw==
+xlucene-parser@^0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.51.0.tgz#57861ac1a8d1a7471f8445dc41768f7a607c26b0"
+  integrity sha512-xNwlLgAtVmbdBQ2EqgeD+YXIjg45IMEkjxptbRCWQFysSfgkkrlFjVBTWwQvwaS1sPciMjJDgxo9eOL6PHCRcA==
   dependencies:
-    "@terascope/types" "^0.11.2"
-    "@terascope/utils" "^0.51.0"
+    "@terascope/types" "^0.12.0"
+    "@terascope/utils" "^0.52.0"
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
standard-asset-apis:
- dependencies:
  - @terascope/utils from 0.51.0 to 0.52.0
- types:
  - @types/jest from 29.5.10 to 29.5.11

standard:
- dependencies:
  - @terascope/utils from 0.51.0 to 0.52.0
  - @terascope/job-components from 0.64.0 to 0.65.0
  - ts-transforms from 0.77.0 to 0.78.0

standard-asset-bundle:
- dev-dependencies:
  - @terascope/job-components from 0.64.0 to 0.65.0
  - @terascope/scripts from 0.62.0 to 0.63.0
- types:
  - @types/jest from 29.5.10 to 29.5.11
  - @types/node from 18.18.9 to 18.19.3