### PR TITLE
Update deprecated method in faker dependency

### DIFF
--- a/asset/src/data_generator/data-schema.ts
+++ b/asset/src/data_generator/data-schema.ts
@@ -61,7 +61,7 @@ const nativeSchema = {
         faker: 'internet.url'
     },
     uuid: {
-        faker: 'datatype.uuid'
+        faker: 'string.uuid'
     },
     created: {
         function: dateNow


### PR DESCRIPTION
- Changed faker dependency to use `string.uuid` instead of `datatype.uuid` to fix deprecation warning cluttering worker logs. 
  - This is specific to workers that are running `data_generator` operations.

This is a fix to issue #767