### PR TITLE
update promMetrics interface and use collect fn

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@faker-js/faker": "^8.4.1",
-        "@terascope/job-components": "^0.74.1",
+        "@terascope/job-components": "^0.74.2",
         "@terascope/standard-asset-apis": "^0.7.2",
         "@terascope/utils": "^0.59.1",
         "@types/chance": "^1.1.4",

--- a/asset/package.json
+++ b/asset/package.json
@@ -21,9 +21,9 @@
     },
     "dependencies": {
         "@faker-js/faker": "^8.4.1",
-        "@terascope/job-components": "^0.73.0",
+        "@terascope/job-components": "^0.74.1",
         "@terascope/standard-asset-apis": "^0.7.2",
-        "@terascope/utils": "^0.58.0",
+        "@terascope/utils": "^0.59.1",
         "@types/chance": "^1.1.4",
         "@types/express": "^4.17.19",
         "chance": "^1.1.11",
@@ -33,7 +33,7 @@
         "randexp": "^0.5.3",
         "short-unique-id": "^5.2.0",
         "timsort": "^0.3.0",
-        "ts-transforms": "^0.84.0",
+        "ts-transforms": "^0.85.1",
         "tslib": "^2.6.2"
     },
     "engines": {

--- a/asset/src/count_by_field/processor.ts
+++ b/asset/src/count_by_field/processor.ts
@@ -3,25 +3,55 @@ import {
 } from '@terascope/job-components';
 import { CountByFieldConfig } from './interfaces';
 
+type Counters = {
+    [valueAsString: string]: {
+        countSinceLastInc: number;
+    };
+}
 export default class CountByField extends MapProcessor<CountByFieldConfig> {
+    counters: Counters = {};
     async initialize(): Promise<void> {
-        if (this.opConfig.collect_metrics) {
+        const { opConfig, counters } = this;
+        if (opConfig.collect_metrics) {
             const name = `${this.opConfig._op}_count_total`;
             const help = `${this.opConfig._op} value field count`;
-            const labelNames = ['value', 'field', 'op_name'];
-            const type = 'counter';
-            await this.context.apis.foundation.promMetrics.addMetric(name, help, labelNames, type);
+            const labelNames = ['value', 'value_type', 'field', 'op_name'];
+            await this.context.apis.foundation.promMetrics.addCounter(
+                name,
+                help,
+                labelNames,
+                function collect() {
+                    for (const [valueAsString, countObj] of Object.entries(counters)) {
+                        this.inc(
+                            {
+                                value: valueAsString,
+                                field: opConfig.field,
+                                op_name: opConfig._op
+                            },
+                            countObj.countSinceLastInc
+                        );
+                        counters[valueAsString].countSinceLastInc = 0;
+                    }
+                }
+            );
         }
     }
 
     _incMetric(doc: DataEntity) {
         if (this.opConfig.collect_metrics) {
-            const metricLabels = {
-                value: doc[this.opConfig.field],
-                field: this.opConfig.field,
-                op_name: this.opConfig._op
-            };
-            this.context.apis.foundation.promMetrics.inc(`${this.opConfig._op}_count_total`, metricLabels, 1);
+            const value = doc[this.opConfig.field];
+
+            // prevents a number and a string representation of a number
+            // to be seen as the same key. "6" !== 6
+            const valueAsString: string = JSON.stringify(value);
+
+            if (!this.counters[valueAsString]) {
+                this.counters[valueAsString] = {
+                    countSinceLastInc: 0
+                };
+            }
+
+            this.counters[valueAsString].countSinceLastInc += 1;
         }
         return doc;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "0.24.0",
+    "version": "0.24.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/job-components": "^0.73.0",
-        "@terascope/scripts": "0.76.0",
+        "@terascope/job-components": "^0.74.1",
+        "@terascope/scripts": "0.77.1",
         "@terascope/standard-asset-apis": "^0.7.2",
         "@types/express": "^4.17.19",
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/job-components": "^0.74.1",
+        "@terascope/job-components": "^0.74.2",
         "@terascope/scripts": "0.77.1",
         "@terascope/standard-asset-apis": "^0.7.2",
         "@types/express": "^4.17.19",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "^2.0.1",
-        "@terascope/utils": "^0.58.0"
+        "@terascope/utils": "^0.59.1"
     },
     "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/test/count_by_field/processor-spec.ts
+++ b/test/count_by_field/processor-spec.ts
@@ -29,9 +29,9 @@ describe('count_by_field processor', () => {
 
     async function makeTest(testConfig: AnyObject = {}) {
         const jobWithCollectMetrics = newTestJobConfig({
-            prom_metrics_enabled: true,
-            prom_metrics_port: testConfig.tf_prom_metrics_port,
-            prom_metrics_add_default: testConfig.tf_prom_metrics_add_default,
+            prom_metrics_enabled: testConfig.job_prom_metrics_enabled,
+            prom_metrics_port: testConfig.job_prom_metrics_port,
+            prom_metrics_add_default: testConfig.job_prom_metrics_add_default,
             operations: [
                 {
                     _op: 'test-reader',
@@ -41,13 +41,13 @@ describe('count_by_field processor', () => {
                 {
                     _op: 'count_by_field',
                     field: 'node_id',
-                    collect_metrics: testConfig.tf_prom_metrics_enabled
+                    collect_metrics: testConfig.job_prom_metrics_enabled
 
                 },
                 {
                     _op: 'count_by_field',
                     field: 'ip',
-                    collect_metrics: testConfig.tf_prom_metrics_enabled
+                    collect_metrics: testConfig.job_prom_metrics_enabled
 
                 },
                 {
@@ -61,17 +61,29 @@ describe('count_by_field processor', () => {
             cluster_manager_type: 'kubernetes'
         });
 
+        await harness.context.apis.foundation.promMetrics.init({
+            assignment: 'worker',
+            logger: harness.context.logger,
+            tf_prom_metrics_enabled: false,
+            tf_prom_metrics_port: 3333,
+            tf_prom_metrics_add_default: true,
+            job_prom_metrics_enabled: testConfig.job_prom_metrics_enabled,
+            job_prom_metrics_port: testConfig.job_prom_metrics_port,
+            job_prom_metrics_add_default: testConfig.job_prom_metrics_add_default,
+        });
         await harness.initialize();
 
         return harness;
     }
 
     afterEach(async () => {
+        await harness.context.apis.foundation.promMetrics.deleteMetric('count_by_field_count_total');
         await harness.context.apis.foundation.promMetrics.shutdown();
         await harness.shutdown();
         await harness.flush();
     });
     afterAll(async () => {
+        await harness.context.apis.foundation.promMetrics.deleteMetric('count_by_field_count_total');
         await harness.context.apis.foundation.promMetrics.shutdown();
         await harness.shutdown();
         await harness.flush();
@@ -79,9 +91,9 @@ describe('count_by_field processor', () => {
 
     it('should generate an empty result if no input data', async () => {
         const testConfig = {
-            tf_prom_metrics_port: 3350,
-            tf_prom_metrics_enabled: false,
-            tf_prom_metrics_use_default: false
+            job_prom_metrics_port: 3350,
+            job_prom_metrics_enabled: false,
+            job_prom_metrics_add_default: false
         };
         const test = await makeTest(testConfig);
         const results = await test.runSlice([]);
@@ -91,24 +103,24 @@ describe('count_by_field processor', () => {
 
     it('should just pass doc when collect metrics is false', async () => {
         const testConfig = {
-            tf_prom_metrics_port: 3351,
-            tf_prom_metrics_enabled: false,
-            tf_prom_metrics_use_default: false
+            job_prom_metrics_port: 3351,
+            job_prom_metrics_enabled: false,
+            job_prom_metrics_add_default: false
         };
         const test = await makeTest(testConfig);
 
         const results = await test.runSlice(cloneDeep(data)) as DataEntity[];
 
         expect(results).toBeArrayOfSize(4);
-        const response = test.context.mockPromMetrics?.count_by_field_count_total;
-        expect(response).toBe(undefined);
+        const metrics = await test.context.apis.scrapePromMetrics();
+        expect(metrics).toBe('');
     });
 
     it('should include metrics when collect metrics is true', async () => {
         const testConfig = {
-            tf_prom_metrics_port: 3353,
-            tf_prom_metrics_enabled: true,
-            tf_prom_metrics_use_default: false
+            job_prom_metrics_port: 3353,
+            job_prom_metrics_enabled: true,
+            job_prom_metrics_add_default: false
         };
         const test = await makeTest(testConfig);
 
@@ -118,19 +130,40 @@ describe('count_by_field processor', () => {
             expect(DataEntity.isDataEntity(doc)).toBe(true);
         });
         expect(results).toBeArrayOfSize(4);
+        const metrics = await test.context.apis.scrapePromMetrics();
+        const nodeIdLines = metrics.split('\n').filter((line:string) => line.includes('node_id'));
+        expect(nodeIdLines.length).toBe(3);
+        expect(nodeIdLines[0].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="100",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[0].split(' ')[1]).toBe('1');
+        expect(nodeIdLines[1].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="101",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[1].split(' ')[1]).toBe('2');
+        expect(nodeIdLines[2].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="undefined",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[2].split(' ')[1]).toBe('1');
 
-        const metricName = 'count_by_field_count_total';
-
-        const response = test.context.mockPromMetrics?.[metricName];
-
-        expect(response?.name).toEqual(metricName);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:100,'].value).toEqual(1);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:101,'].value).toEqual(2);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:undefined,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.2,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.3,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.4,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.5,'].value).toEqual(1);
+        const ipLines = metrics.split('\n').filter((line:string) => line.includes('ip'));
+        expect(ipLines.length).toBe(4);
+        expect(ipLines[0].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.4\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[0].split(' ')[1]).toBe('1');
+        expect(ipLines[1].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.5\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[1].split(' ')[1]).toBe('1');
+        expect(ipLines[2].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.2\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[2].split(' ')[1]).toBe('1');
+        expect(ipLines[3].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.3\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[3].split(' ')[1]).toBe('1');
     });
 
     it('should differentiate between same value with different type', async () => {
@@ -165,9 +198,9 @@ describe('count_by_field processor', () => {
         ];
 
         const testConfig = {
-            tf_prom_metrics_port: 3353,
-            tf_prom_metrics_enabled: true,
-            tf_prom_metrics_use_default: false
+            job_prom_metrics_port: 3353,
+            job_prom_metrics_enabled: true,
+            job_prom_metrics_add_default: false
         };
         const test = await makeTest(testConfig);
 
@@ -178,21 +211,39 @@ describe('count_by_field processor', () => {
         });
         expect(results).toBeArrayOfSize(7);
 
-        const metricName = 'count_by_field_count_total';
+        const metrics = await test.context.apis.scrapePromMetrics();
+        const nodeIdLines = metrics.split('\n').filter((line:string) => line.includes('node_id'));
+        expect(nodeIdLines.length).toBe(5);
+        expect(nodeIdLines[0].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="100",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[0].split(' ')[1]).toBe('1');
+        expect(nodeIdLines[1].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="101",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[1].split(' ')[1]).toBe('2');
+        expect(nodeIdLines[2].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="undefined",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[2].split(' ')[1]).toBe('1');
 
-        // console.log('@@@@ mockPromMetrics: ', test.context.mockPromMetrics);
-        const response = test.context.mockPromMetrics?.[metricName];
-        // console.log('@@@@ response: ', response);
-
-        expect(response?.name).toEqual(metricName);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:100,'].value).toEqual(1);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:101,'].value).toEqual(2);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:"100",'].value).toEqual(1);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:"101",'].value).toEqual(2);
-        expect(response?.labels['field:node_id,op_name:count_by_field,value:undefined,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.2,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.3,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.4,'].value).toEqual(1);
-        expect(response?.labels['field:ip,op_name:count_by_field,value:192.168.0.5,'].value).toEqual(1);
+        const ipLines = metrics.split('\n').filter((line:string) => line.includes('ip'));
+        expect(ipLines.length).toBe(4);
+        expect(ipLines[0].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.4\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[0].split(' ')[1]).toBe('2');
+        expect(ipLines[1].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.5\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[1].split(' ')[1]).toBe('2');
+        expect(ipLines[2].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.2\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[2].split(' ')[1]).toBe('2');
+        expect(ipLines[3].split(' ')[0])
+            // eslint-disable-next-line no-useless-escape
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.3\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(ipLines[3].split(' ')[1]).toBe('1');
     });
 });

--- a/test/count_by_field/processor-spec.ts
+++ b/test/count_by_field/processor-spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import 'jest-extended';
 import { DataEntity, cloneDeep, AnyObject } from '@terascope/job-components';
 import { WorkerTestHarness, newTestJobConfig } from 'teraslice-test-harness';
@@ -110,8 +111,8 @@ describe('count_by_field processor', () => {
         const test = await makeTest(testConfig);
 
         const results = await test.runSlice(cloneDeep(data)) as DataEntity[];
-
         expect(results).toBeArrayOfSize(4);
+
         const metrics = await test.context.apis.scrapePromMetrics();
         expect(metrics).toBe('');
     });
@@ -130,38 +131,40 @@ describe('count_by_field processor', () => {
             expect(DataEntity.isDataEntity(doc)).toBe(true);
         });
         expect(results).toBeArrayOfSize(4);
-        const metrics = await test.context.apis.scrapePromMetrics();
+
+        const metrics:string = await test.context.apis.scrapePromMetrics();
+
         const nodeIdLines = metrics.split('\n').filter((line:string) => line.includes('node_id'));
         expect(nodeIdLines.length).toBe(3);
+
         expect(nodeIdLines[0].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="100",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(nodeIdLines[0].split(' ')[1]).toBe('1');
+
         expect(nodeIdLines[1].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="101",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(nodeIdLines[1].split(' ')[1]).toBe('2');
+
         expect(nodeIdLines[2].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="undefined",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(nodeIdLines[2].split(' ')[1]).toBe('1');
 
         const ipLines = metrics.split('\n').filter((line:string) => line.includes('ip'));
         expect(ipLines.length).toBe(4);
+
         expect(ipLines[0].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.4\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[0].split(' ')[1]).toBe('1');
+
         expect(ipLines[1].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.5\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[1].split(' ')[1]).toBe('1');
+
         expect(ipLines[2].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.2\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[2].split(' ')[1]).toBe('1');
+
         expect(ipLines[3].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.3\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[3].split(' ')[1]).toBe('1');
     });
@@ -211,38 +214,46 @@ describe('count_by_field processor', () => {
         });
         expect(results).toBeArrayOfSize(7);
 
-        const metrics = await test.context.apis.scrapePromMetrics();
+        const metrics:string = await test.context.apis.scrapePromMetrics();
         const nodeIdLines = metrics.split('\n').filter((line:string) => line.includes('node_id'));
         expect(nodeIdLines.length).toBe(5);
+
         expect(nodeIdLines[0].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="100",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(nodeIdLines[0].split(' ')[1]).toBe('1');
+
         expect(nodeIdLines[1].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="101",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(nodeIdLines[1].split(' ')[1]).toBe('2');
+
         expect(nodeIdLines[2].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="undefined",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(nodeIdLines[2].split(' ')[1]).toBe('1');
 
+        expect(nodeIdLines[3].split(' ')[0])
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"100\\\"",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[3].split(' ')[1]).toBe('1');
+
+        expect(nodeIdLines[4].split(' ')[0])
+            .toBe('teraslice_worker_count_by_field_count_total{value="\\\"101\\\"",field="node_id",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
+        expect(nodeIdLines[4].split(' ')[1]).toBe('2');
+
         const ipLines = metrics.split('\n').filter((line:string) => line.includes('ip'));
         expect(ipLines.length).toBe(4);
+
         expect(ipLines[0].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.4\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[0].split(' ')[1]).toBe('2');
+
         expect(ipLines[1].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.5\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[1].split(' ')[1]).toBe('2');
+
         expect(ipLines[2].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.2\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[2].split(' ')[1]).toBe('2');
+
         expect(ipLines[3].split(' ')[0])
-            // eslint-disable-next-line no-useless-escape
             .toBe('teraslice_worker_count_by_field_count_total{value="\\\"192.168.0.3\\\"",field="ip",op_name="count_by_field",name=\"mockPromMetrics\",assignment=\"worker\"}');
         expect(ipLines[3].split(' ')[1]).toBe('1');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,9 +335,9 @@
     regenerator-runtime "^0.13.11"
 
 "@babel/runtime@^7.21.0":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
-  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
+  integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -783,20 +783,20 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@terascope/data-mate@^0.55.0":
-  version "0.55.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.55.0.tgz#e3267268cef0dee4873f4b039d2ea8e280fdfe24"
-  integrity sha512-eQDlS0qc2Y1wt4YGl6OmXOFOC3+FK6PfRfWu6Cuaf7F9yMPjp+IXis4zbJcUinTVKV0Wrqtv3kkFfmotvQwGuA==
+"@terascope/data-mate@^0.56.1":
+  version "0.56.1"
+  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.56.1.tgz#d8983281a5e95382c053d5a89d5f3ae57ff748e1"
+  integrity sha512-4jLzqD5K1bpSz/6dKVEmaVlTczQrOjxcx5GMAFA7xN6MEO3UWKxEpIvB3e0JE5ooqcMNJt6I9+jUaFOdC28H1A==
   dependencies:
-    "@terascope/data-types" "^0.49.0"
-    "@terascope/types" "^0.16.0"
-    "@terascope/utils" "^0.58.0"
+    "@terascope/data-types" "^0.50.1"
+    "@terascope/types" "^0.17.1"
+    "@terascope/utils" "^0.59.1"
     "@types/validator" "^13.11.9"
     awesome-phonenumber "^2.70.0"
     date-fns "^2.30.0"
     ip-bigint "^3.0.3"
     ip6addr "^0.2.5"
-    ipaddr.js "^2.0.1"
+    ipaddr.js "^2.2.0"
     is-cidr "^4.0.2"
     is-ip "^3.1.0"
     jexl "^2.2.2"
@@ -805,15 +805,15 @@
     uuid "^9.0.1"
     valid-url "^1.0.9"
     validator "^13.11.0"
-    xlucene-parser "^0.57.0"
+    xlucene-parser "^0.58.1"
 
-"@terascope/data-types@^0.49.0":
-  version "0.49.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.49.0.tgz#e1994e61510a47b4cb2b3de29944cae3c798dda6"
-  integrity sha512-kcwP7aQZ6gbfjn8LghROC2aevLjZNmj3iqcNMQnuH3ZMcLmBV6BEQ7gKaqQejXI2Q7OL4/QsL/twYoaKeb+RYA==
+"@terascope/data-types@^0.50.1":
+  version "0.50.1"
+  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.50.1.tgz#7a06f0fff35a7c79981f44575b958df665c33303"
+  integrity sha512-GbL1yT5veODH41Pp0h0GkNexOpZlJBQkKerak3sgpegZ9nJgmvp3yBJMMsAtE4TDMM2xprMlsv2Fe2ow1cvsdA==
   dependencies:
-    "@terascope/types" "^0.16.0"
-    "@terascope/utils" "^0.58.0"
+    "@terascope/types" "^0.17.1"
+    "@terascope/utils" "^0.59.1"
     graphql "^14.7.0"
     lodash "^4.17.21"
     yargs "^17.7.2"
@@ -845,31 +845,31 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.73.0":
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.73.0.tgz#2463bacb77d0486206ee5ab438c0e266148b9074"
-  integrity sha512-c8hz0OCrs9byd99yLDprMQbl1RrlueuaElKR5OOM/gGraLmcz2Au59+IzaoUotYSRK9nwwNhcoZjk+jLpZukoA==
+"@terascope/job-components@^0.74.1":
+  version "0.74.1"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.74.1.tgz#374fda9ba69a7ee035110ac13c5fe2a28a2f5bfe"
+  integrity sha512-DjDj2qGUIJVpiw8HGcdVCuEZsM8hi3d8GchNKFbherxyD7rtv3y+56nbT/rtHSoK8RhCuJTxfdaLwzpdLlpQcg==
   dependencies:
-    "@terascope/utils" "^0.58.0"
+    "@terascope/utils" "^0.59.1"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
     datemath-parser "^1.0.6"
     uuid "^9.0.1"
 
-"@terascope/scripts@0.76.0":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.76.0.tgz#95ce61423a7bba93cea12f76dfac7e3a1fe8467a"
-  integrity sha512-yIWVXdCVBuR89hfnJuOy0uUmQKQn+B7LEiUca7UoXCEivYdpfbrPYDvOh9KSbs08BJW4z9lNRVCIt4oTpV1S5Q==
+"@terascope/scripts@0.77.1":
+  version "0.77.1"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.77.1.tgz#d5571e3a7c4f5cdee0b573802455bac2c1ce7888"
+  integrity sha512-zlcnb+QqK76S5TmrBEzXrvBuvnbDUdIduNxYxoOu+RN2QAp5lsU2wLMBoy4P0Hqsgu/ctnilR6Nf76805dZLOQ==
   dependencies:
     "@kubernetes/client-node" "^0.20.0"
-    "@terascope/utils" "^0.58.0"
+    "@terascope/utils" "^0.59.1"
     codecov "^3.8.3"
     execa "^5.1.0"
     fs-extra "^11.2.0"
     globby "^11.0.4"
     got "^11.8.3"
-    ip "^1.1.9"
+    ip "^2.0.1"
     js-yaml "^4.1.0"
     kafkajs "^2.2.4"
     lodash "^4.17.21"
@@ -878,7 +878,7 @@
     ms "^2.1.3"
     package-json "^7.0.0"
     pkg-up "^3.1.0"
-    semver "^7.6.0"
+    semver "^7.6.1"
     signale "^1.4.0"
     sort-package-json "~1.57.0"
     toposort "^2.0.2"
@@ -893,17 +893,19 @@
   dependencies:
     bluebird "^3.7.2"
 
-"@terascope/types@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.16.0.tgz#c9d69496ce2784a9d7704a7d848fb6ccf0cd627a"
-  integrity sha512-W+D0c3XuGws25nXcig3WD/bx3c3GMP9dgwF76+CryqX+l+rnvRmjM1nNWIBBGUJHSmtOAX0iX3HofUIDrH5hCQ==
-
-"@terascope/utils@^0.58.0":
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.58.0.tgz#a8f0b85a23c03e322f291a2fd7688c7625fbd2dc"
-  integrity sha512-napysCM9bVRURzUev8iHHHG9naSzY8Jsdl4jjbj3UZK1IK3hRcwRijvRyRw713W8+UFHyZfkHdCsjENxc1Os7g==
+"@terascope/types@^0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.17.1.tgz#7e82d5478cdc7a13ab940f36f985fd918318fbbc"
+  integrity sha512-hVVbwocV19EUY2xNo4c2eRd0i3a3+dmaJlRHHocsI/0cjxRl3jpivla62vEkMDrCqydvTis1kv2+5LmH23+c1A==
   dependencies:
-    "@terascope/types" "^0.16.0"
+    prom-client "^15.1.2"
+
+"@terascope/utils@^0.59.1":
+  version "0.59.1"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.59.1.tgz#372f960c5c0fc250ed0c481be20bbd49ed6937bb"
+  integrity sha512-lIfRdTQ9nBwBDWM1VnLOjkarPWltZ2RmLvXpxPbma6Kl890mAOzdQyjXx8vi5QEgaApvVT7Ady19bTcJImD5Cw==
+  dependencies:
+    "@terascope/types" "^0.17.1"
     "@turf/bbox" "^6.4.0"
     "@turf/bbox-polygon" "^6.4.0"
     "@turf/boolean-contains" "^6.4.0"
@@ -927,7 +929,7 @@
     ip-bigint "^3.0.3"
     ip-cidr "^3.1.0"
     ip6addr "^0.2.5"
-    ipaddr.js "^2.0.1"
+    ipaddr.js "^2.2.0"
     is-cidr "^4.0.2"
     is-ip "^3.1.0"
     is-plain-object "^5.0.0"
@@ -1296,9 +1298,9 @@
     "@types/node" "*"
 
 "@types/lodash@^4.14.202":
-  version "4.14.202"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
-  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.1.tgz#0fabfcf2f2127ef73b119d98452bd317c4a17eb8"
+  integrity sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==
 
 "@types/mime@*":
   version "3.0.4"
@@ -2018,15 +2020,16 @@ call-bind@^1.0.0:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-call-bind@^1.0.2:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.6.tgz#6c46675fc7a5e9de82d75a233d586c8b7ac0d931"
-  integrity sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==
+call-bind@^1.0.2, call-bind@^1.0.6, call-bind@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
+  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
   dependencies:
+    es-define-property "^1.0.0"
     es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.3"
-    set-function-length "^1.2.0"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.1"
 
 call-bind@^1.0.4, call-bind@^1.0.5:
   version "1.0.5"
@@ -2478,7 +2481,16 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
-define-data-property@^1.0.1, define-data-property@^1.1.1:
+define-data-property@^1.0.1, define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
+
+define-data-property@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
   integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
@@ -2486,16 +2498,6 @@ define-data-property@^1.0.1, define-data-property@^1.1.1:
     get-intrinsic "^1.2.1"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.0"
-
-define-data-property@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.3.tgz#281845e04737d709c2de99e278546189b65d3055"
-  integrity sha512-h3GBouC+RPtNX2N0hHVLo2ZwPYurq8mLmXpOLTsw71gr7lHt5VaI4vVkDUNOfiWmm48JEXe3VM7PmLX45AMmmg==
-  dependencies:
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.4"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.1"
 
 define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
@@ -2706,6 +2708,13 @@ es-abstract@^1.22.1:
     typed-array-length "^1.0.4"
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.13"
+
+es-define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
+  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
+  dependencies:
+    get-intrinsic "^1.2.4"
 
 es-errors@^1.3.0:
   version "1.3.0"
@@ -3451,7 +3460,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
   integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
@@ -3462,7 +3471,7 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
+get-intrinsic@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
   integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
@@ -3470,16 +3479,6 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.3"
-
-get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.2.tgz#281b7622971123e1ef4b3c90fd7539306da93f3b"
-  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
-  dependencies:
-    function-bind "^1.1.2"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
-    hasown "^2.0.0"
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -3690,17 +3689,17 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
-  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
   dependencies:
-    get-intrinsic "^1.2.2"
+    es-define-property "^1.0.0"
 
 has-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
-  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.3.tgz#b31ddfe9b0e6e9914536a6ab286426d0214f77fd"
+  integrity sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==
 
 has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
@@ -3725,9 +3724,9 @@ has@^1.0.3:
   integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
 
 hasown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
-  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
 
@@ -3904,20 +3903,20 @@ ip6addr@^0.2.5:
     assert-plus "^1.0.0"
     jsprim "^2.0.2"
 
-ip@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
-  integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==
+ip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
+  integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-ipaddr.js@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.1.0.tgz#2119bc447ff8c257753b196fc5f1ce08a4cdf39f"
-  integrity sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==
+ipaddr.js@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.2.0.tgz#d33fa7bac284f4de7af949638c9d68157c6b92e8"
+  integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==
 
 is-arguments@^1.1.1:
   version "1.1.1"
@@ -5238,12 +5237,12 @@ object-inspect@^1.13.1:
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
 
 object-is@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
+  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -5805,13 +5804,14 @@ regexp.prototype.flags@^1.4.3, regexp.prototype.flags@^1.5.0:
     functions-have-names "^1.2.3"
 
 regexp.prototype.flags@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz#90ce989138db209f81492edd734183ce99f9677e"
-  integrity sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
+  integrity sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    set-function-name "^2.0.0"
+    call-bind "^1.0.6"
+    define-properties "^1.2.1"
+    es-errors "^1.3.0"
+    set-function-name "^2.0.1"
 
 registry-auth-token@^4.0.0:
   version "4.2.2"
@@ -6008,12 +6008,17 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
+semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.1:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
 
 send@0.18.0:
   version "0.18.0"
@@ -6054,19 +6059,19 @@ set-function-length@^1.1.1:
     gopd "^1.0.1"
     has-property-descriptors "^1.0.0"
 
-set-function-length@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.1.tgz#47cc5945f2c771e2cf261c6737cf9684a2a5e425"
-  integrity sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==
+set-function-length@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
   dependencies:
-    define-data-property "^1.1.2"
+    define-data-property "^1.1.4"
     es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.3"
+    get-intrinsic "^1.2.4"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.1"
+    has-property-descriptors "^1.0.2"
 
-set-function-name@^2.0.0, set-function-name@^2.0.1:
+set-function-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.1.tgz#12ce38b7954310b9f61faa12701620a0c882793a"
   integrity sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==
@@ -6570,14 +6575,14 @@ ts-jest@^29.1.2:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-ts-transforms@^0.84.0:
-  version "0.84.0"
-  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.84.0.tgz#53052dbd0a561b1ecf8b9ee062328091168c2469"
-  integrity sha512-YHCEFre2wrBFC0vG8M0KjHS50ceez9xRgLbQSU+8Px28WcPPpX3VxYDQV9B5Qb3ZeaijK8d0+wNwEgoCaavsyQ==
+ts-transforms@^0.85.1:
+  version "0.85.1"
+  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.85.1.tgz#0231aa3cb345295ad66eb54a06665e2fce8d09a3"
+  integrity sha512-cjbPP99STXqoF+HmjuZZ8xUchwg9YEisBtbOG0MnjU7DekOKVfsRcAXEL/C7V1TlCpHkLl+qna3uxqMLYvVIrA==
   dependencies:
-    "@terascope/data-mate" "^0.55.0"
-    "@terascope/types" "^0.16.0"
-    "@terascope/utils" "^0.58.0"
+    "@terascope/data-mate" "^0.56.1"
+    "@terascope/types" "^0.17.1"
+    "@terascope/utils" "^0.59.1"
     awesome-phonenumber "^2.70.0"
     graphlib "^2.1.8"
     is-ip "^3.1.0"
@@ -6833,7 +6838,12 @@ valid-url@^1.0.9:
   resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
   integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
 
-validator@^13.11.0, validator@^13.6.0:
+validator@^13.11.0:
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.12.0.tgz#7d78e76ba85504da3fee4fd1922b385914d4b35f"
+  integrity sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==
+
+validator@^13.6.0:
   version "13.11.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
   integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
@@ -6990,13 +7000,13 @@ ws@^8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
-xlucene-parser@^0.57.0:
-  version "0.57.0"
-  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.57.0.tgz#211ad6e7ea8aa704b9a7d027f2115d0a7303ed86"
-  integrity sha512-+q0hrR+Cm7SVoLsxYNafLFAfTAbAYH1hssl9akdn6IqELO5SElgHSdMeC67NoBT3OFSBr60f9fbm1BnzSt5KkA==
+xlucene-parser@^0.58.1:
+  version "0.58.1"
+  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.58.1.tgz#1c78b7ede0965c90de7339d88b99fe2afbccec47"
+  integrity sha512-rUNuDtsZi6vP19svhJjUxnWCl/M5lq4WP2ToVl91/HQiFAHB27Z9CmU4uUod8CagOAx+aMhlBgQVxMO/cj802Q==
   dependencies:
-    "@terascope/types" "^0.16.0"
-    "@terascope/utils" "^0.58.0"
+    "@terascope/types" "^0.17.1"
+    "@terascope/utils" "^0.59.1"
 
 xtend@^4.0.0:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,16 +845,17 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.74.1":
-  version "0.74.1"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.74.1.tgz#374fda9ba69a7ee035110ac13c5fe2a28a2f5bfe"
-  integrity sha512-DjDj2qGUIJVpiw8HGcdVCuEZsM8hi3d8GchNKFbherxyD7rtv3y+56nbT/rtHSoK8RhCuJTxfdaLwzpdLlpQcg==
+"@terascope/job-components@^0.74.2":
+  version "0.74.2"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.74.2.tgz#de875f792644abf3324f74d98e6b7daa046d7fff"
+  integrity sha512-FEliIWkcK43Q+kiONkwutXgV/f9qQMGUjesmJq9IyqYswOd7ZHtlXCjBUziKqdUWZ01OZ3YDzFxeuufJoLflUg==
   dependencies:
     "@terascope/utils" "^0.59.1"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
     datemath-parser "^1.0.6"
+    prom-client "^15.1.2"
     uuid "^9.0.1"
 
 "@terascope/scripts@0.77.1":


### PR DESCRIPTION
This PR makes the following changes:
- adds a static object `counters` to `CountByField` to track all field counts across multiple operations
- add default labels from worker to `count_by_field_count_total` metric
- `addCounter` now uses a `collect()` function to increment count only at time of `/metrics` endpoint scrape 
- `_incMetric` now increments its value in `counters` instead of the `promMetrics` directly
- tests that use `promMetrics` now manually init the API
- tests use `test.context.apis.scrapePromMetrics()` to get metrics directly from `prom-client`