### PR TITLE
Add node 22 workflows

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f6b34eb9b2ea5d113078381237ca81e5520e6f5b
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@73a80a9e19cde53baf8a918e2c7c69bf39ca884a
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@f6b34eb9b2ea5d113078381237ca81e5520e6f5b
+    uses: terascope/workflows/.github/workflows/asset-test.yml@73a80a9e19cde53baf8a918e2c7c69bf39ca884a
     secrets: inherit

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "workspaces": [


### PR DESCRIPTION
This PR makes the following changes:

- Updates github actions workflow that includes node `v22.2.0` 
- Bumps **standard-assets** to `v0.25.0`