### PR TITLE
Backwards compatibility fix for teraslice 

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@faker-js/faker": "^8.4.1",
-        "@terascope/job-components": "^0.74.2",
+        "@terascope/job-components": "^0.75.0",
         "@terascope/standard-asset-apis": "^0.7.2",
         "@terascope/utils": "^0.59.1",
         "@types/chance": "^1.1.4",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/src/count_by_field/processor.ts
+++ b/asset/src/count_by_field/processor.ts
@@ -1,5 +1,5 @@
 import {
-    MapProcessor, DataEntity
+    MapProcessor, DataEntity, isPromAvailable
 } from '@terascope/job-components';
 import { CountByFieldConfig } from './interfaces';
 
@@ -13,7 +13,7 @@ export default class CountByField extends MapProcessor<CountByFieldConfig> {
     static counters: Counters = {};
     async initialize(): Promise<void> {
         const { opConfig, context } = this;
-        if (opConfig.collect_metrics) {
+        if (opConfig.collect_metrics && isPromAvailable(context)) {
             const defaultLabels = context.apis.foundation.promMetrics.getDefaultLabels();
             const name = `${this.opConfig._op}_count_total`;
             const help = `${this.opConfig._op} value field count`;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/job-components": "^0.74.2",
+        "@terascope/job-components": "^0.75.0",
         "@terascope/scripts": "0.77.2",
         "@terascope/standard-asset-apis": "^0.7.2",
         "@types/express": "^4.17.19",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,12 +845,12 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.74.2":
-  version "0.74.2"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.74.2.tgz#de875f792644abf3324f74d98e6b7daa046d7fff"
-  integrity sha512-FEliIWkcK43Q+kiONkwutXgV/f9qQMGUjesmJq9IyqYswOd7ZHtlXCjBUziKqdUWZ01OZ3YDzFxeuufJoLflUg==
+"@terascope/job-components@^0.75.0":
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.75.0.tgz#03739729d7d7aee722b6291418987084cf65aaa9"
+  integrity sha512-QbIAKfbjX5Wj8A/hZvjE0E8y9hvW9QecQIw6eMwTRneudx2OPQcissCCYNlxBpfP13dK/U85BIqOVFZRTh8KcA==
   dependencies:
-    "@terascope/utils" "^0.59.1"
+    "@terascope/utils" "^0.59.2"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"


### PR DESCRIPTION
This PR makes the following changes:

- Introduces backwards compatibility for teraslice versions before `v1.4.0`
  - This fixes an issue where using a teraslice version older than version `v1.4.0` would throw `TypeError: this.promMetrics.addGauge is not a function`
- Bump **standard-assets** to `v0.25.1`
- Updates the following dependencies:
  - **@terascope/job-components** from `v0.74.2` to `v0.75.0`

ref: https://github.com/terascope/teraslice/issues/3625