### PR TITLE
Bundled dependency updates

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "standard",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Teraslice standard processor asset bundle"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/package.json
+++ b/asset/package.json
@@ -22,9 +22,9 @@
     },
     "dependencies": {
         "@faker-js/faker": "^8.4.1",
-        "@terascope/job-components": "^1.1.0",
+        "@terascope/job-components": "^1.2.0",
         "@terascope/standard-asset-apis": "^0.7.2",
-        "@terascope/utils": "^0.60.0",
+        "@terascope/utils": "^1.0.0",
         "@types/chance": "^1.1.4",
         "@types/express": "^4.17.19",
         "chance": "^1.1.12",
@@ -34,7 +34,7 @@
         "randexp": "^0.5.3",
         "short-unique-id": "^5.2.0",
         "timsort": "^0.3.0",
-        "ts-transforms": "^0.86.1",
+        "ts-transforms": "^1.0.3",
         "tslib": "^2.6.3"
     },
     "engines": {

--- a/asset/package.json
+++ b/asset/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@faker-js/faker": "^8.4.1",
         "@terascope/job-components": "^1.2.0",
-        "@terascope/standard-asset-apis": "^0.7.2",
+        "@terascope/standard-asset-apis": "^1.0.0",
         "@terascope/utils": "^1.0.0",
         "@types/chance": "^1.1.4",
         "@types/express": "^4.17.19",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/job-components": "^1.1.0",
-        "@terascope/scripts": "0.83.3",
+        "@terascope/job-components": "^1.2.0",
+        "@terascope/scripts": "1.0.0",
         "@terascope/standard-asset-apis": "^0.7.2",
         "@types/express": "^4.17.19",
         "@types/jest": "^29.5.12",
@@ -43,7 +43,7 @@
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
         "node-notifier": "^10.0.1",
-        "teraslice-test-harness": "^1.1.0",
+        "teraslice-test-harness": "^1.2.0",
         "ts-jest": "^29.2.4",
         "tslib": "^2.6.3",
         "typescript": "~5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@terascope/eslint-config": "^0.8.0",
         "@terascope/job-components": "^1.2.0",
         "@terascope/scripts": "1.0.0",
-        "@terascope/standard-asset-apis": "^0.7.2",
+        "@terascope/standard-asset-apis": "^1.0.0",
         "@types/express": "^4.17.19",
         "@types/jest": "^29.5.12",
         "@types/json2csv": "^5.0.7",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "^2.0.1",
-        "@terascope/utils": "^0.60.0"
+        "@terascope/utils": "^1.0.0"
     },
     "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/standard-asset-apis",
     "displayName": "Standard Asset Apis",
-    "version": "0.7.2",
+    "version": "1.0.0",
     "description": "A common set of tools for data processing",
     "homepage": "https://github.com/terascope/standard-assets",
     "repository": "git@github.com:terascope/standard-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,6 +747,13 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
+"@peggyjs/from-mem@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@peggyjs/from-mem/-/from-mem-1.3.0.tgz#16470cf7dfa22fc75ca217a4e064a5f0c4e1111b"
+  integrity sha512-kzGoIRJjkg3KuGI4bopz9UvF3KguzfxalHRDEIdqEZUe45xezsQ6cx30e0RKuxPUexojQRBfu89Okn7f4/QXsw==
+  dependencies:
+    semver "7.6.0"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -783,14 +790,14 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@terascope/data-mate@^0.57.1":
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-0.57.1.tgz#ca149e056180b5643d59d0b21a5ca0d4b7f1665f"
-  integrity sha512-xK8pAWLR7CDeMXwX1YO1IhY5dOxVGSFnX+CQLtHtMYb9W1lmFDKkqYMzGWDlO3saZkUyKc9Fe8ibGKP/6nAuRA==
+"@terascope/data-mate@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-1.0.3.tgz#0132b919c9b2ae8784b3cb3859222ef17551c565"
+  integrity sha512-NyLJtQdWPkpfrmciK4EXbE2+HEGwedtiksEs8+f2RV0luVPU2EsBCYD04WsYoVCHvemwgavzhsoMcJ3ztvH8Sg==
   dependencies:
-    "@terascope/data-types" "^0.51.0"
-    "@terascope/types" "^0.18.0"
-    "@terascope/utils" "^0.60.0"
+    "@terascope/data-types" "^1.0.0"
+    "@terascope/types" "^1.0.0"
+    "@terascope/utils" "^1.0.0"
     "@types/validator" "^13.11.10"
     awesome-phonenumber "^2.70.0"
     date-fns "^2.30.0"
@@ -805,15 +812,15 @@
     uuid "^9.0.1"
     valid-url "^1.0.9"
     validator "^13.12.0"
-    xlucene-parser "^0.59.0"
+    xlucene-parser "^1.0.2"
 
-"@terascope/data-types@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-0.51.0.tgz#8dc6b2b626d5cb8b76a61b3ac9a0ec351cd18834"
-  integrity sha512-YuU/cDAjAIGZsBHmgI6NxPVAMFPnDdiptEnexmw8wbyhKI8Xd6qL2ufDSlWzKs9ADa14Ua38JaxNmhd7m7+B7Q==
+"@terascope/data-types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-1.0.0.tgz#e01aa967d88ce6c9e80432ac85340e8f252e491e"
+  integrity sha512-XAb9BTZYfvHJArLDAlfWbocfjhHr7z+iHa2J6HxW5zXB79z/c8+SxoyXn7gvODXJx/PHLszkgTZcdEnfCkCPUQ==
   dependencies:
-    "@terascope/types" "^0.18.0"
-    "@terascope/utils" "^0.60.0"
+    "@terascope/types" "^1.0.0"
+    "@terascope/utils" "^1.0.0"
     graphql "^14.7.0"
     lodash "^4.17.21"
     yargs "^17.7.2"
@@ -833,10 +840,10 @@
     eslint-plugin-react "^7.29.4"
     eslint-plugin-react-hooks "^4.4.0"
 
-"@terascope/fetch-github-release@^0.8.10":
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/@terascope/fetch-github-release/-/fetch-github-release-0.8.10.tgz#243b8a50f963f4c2c5771689e2b94e94265db179"
-  integrity sha512-bTLmiEotEca8YTi+PcvznisIHMEKYLU0Uj322rkbMJlr6LqXFvIKv2dzuwMhSADO7eUeKlC4mXUs8Nt2ftpdWA==
+"@terascope/fetch-github-release@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/fetch-github-release/-/fetch-github-release-1.0.0.tgz#72a19cda75c389081f48646a86595087ade348bc"
+  integrity sha512-4I89IyfaL74Ssk60VfAl4dtCS5qdUstIW8fd7x8BD2BJpiw12PYhC6Q8rMmxjPohKWuk6TC/A76TfkkjZJxiOw==
   dependencies:
     extract-zip "^2.0.1"
     got "^11.4.0"
@@ -844,13 +851,13 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.1.0.tgz#f0d0d604831e85e8898c55d72a3bb3231b966980"
-  integrity sha512-iX0h75CXv3KNer7GJp6BKLyULWBD3zgMNvoI8m7wfo94Z2OwCs/m7LM3LQL7fD+i/QpUvlVtHTV4F3oy4EXBOw==
+"@terascope/job-components@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.2.0.tgz#b78da13af6dba42d166cecc1197f7abed860e6a0"
+  integrity sha512-v2yu+x5dA1RAo3jETAC72UOGb4h48fuTCE5u5upsXTm9BCO1o4MX5Vy4JZD6U65JBkDZCBHo/tMyYGKJPVraKQ==
   dependencies:
-    "@terascope/types" "^0.18.0"
-    "@terascope/utils" "^0.60.0"
+    "@terascope/types" "^1.0.0"
+    "@terascope/utils" "^1.0.0"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
@@ -859,13 +866,13 @@
     prom-client "^15.1.2"
     uuid "^9.0.1"
 
-"@terascope/scripts@0.83.3":
-  version "0.83.3"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-0.83.3.tgz#d904943cc783126073b34c66c33b9195f69fc97b"
-  integrity sha512-cuCVYoYZkt22UgnD/DIWOH8Qbo42MZ01rGLGEgwZeesI7j/baBjXOqLmgNJRdLxsz/hUyTbfiPF5RcMmkNUavg==
+"@terascope/scripts@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.0.0.tgz#dec9127ced459a8de151db0bc584c75124f9735f"
+  integrity sha512-E5VMhiF+/eIe5jd9Kf9kGYyy8mPYBPyjV1CtJNE0tbIgZO4CuOlb7hmVwFlOEW4uGI1Q0Xml9OzPpHQi7NZ6Tw==
   dependencies:
     "@kubernetes/client-node" "^0.20.0"
-    "@terascope/utils" "^0.60.0"
+    "@terascope/utils" "^1.0.0"
     codecov "^3.8.3"
     execa "^5.1.0"
     fs-extra "^11.2.0"
@@ -888,19 +895,19 @@
     typedoc-plugin-markdown "~4.0.3"
     yargs "^17.7.2"
 
-"@terascope/types@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-0.18.0.tgz#3e476339466fc3fcf440b5577d146bf93c2aa194"
-  integrity sha512-zTPnf+ncxSSB4ees8i8ZUsl3LXW7mU1ogtmNZMb1Cnp5heH6PYyuoAmnlUCrusvS6sgcejj4S01Sc11SelwLEA==
+"@terascope/types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-1.0.0.tgz#bbccc76c95a52ebc99781316568ae897a520dd68"
+  integrity sha512-hkHJhb6dR31v4KzipiNIYVc0nNVN1BP0A8uGIQutwhLwf9thF6vAjsigoomXq8fnvjTGDskaTkXlsVk81bQQ3w==
   dependencies:
     prom-client "^15.1.2"
 
-"@terascope/utils@^0.60.0":
-  version "0.60.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-0.60.0.tgz#5fb9cf2354ad7ca1d1df47b833b1b3e79f6c922e"
-  integrity sha512-KlgroYtnpSgSkdKlMBEadFQ2Fb7dAkeE0bCC4XApGx2VEWopPMWd2RW1LibuwakIfue2zPR6lgBytab70x12Nw==
+"@terascope/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.0.0.tgz#c470629efd5ae6d5dbd626c98afe3d27389b739f"
+  integrity sha512-cvH9Amvq6jaIDeKWGgdaoANhlNQ7ql2hFqktqYmBb7wKd0tP85HxTBRCPawrhJgRCE1qLZIYdh7QsAj7qCNNiQ==
   dependencies:
-    "@terascope/types" "^0.18.0"
+    "@terascope/types" "^1.0.0"
     "@turf/bbox" "^6.4.0"
     "@turf/bbox-polygon" "^6.4.0"
     "@turf/boolean-contains" "^6.4.0"
@@ -913,7 +920,7 @@
     "@turf/helpers" "^6.2.0"
     "@turf/invariant" "^6.2.0"
     "@turf/line-to-polygon" "^6.4.0"
-    "@types/lodash" "^4.14.202"
+    "@types/lodash-es" "^4.17.12"
     "@types/validator" "^13.11.10"
     awesome-phonenumber "^2.70.0"
     date-fns "^2.30.0"
@@ -931,7 +938,7 @@
     js-string-escape "^1.0.1"
     kind-of "^6.0.3"
     latlon-geohash "^1.1.0"
-    lodash "^4.17.21"
+    lodash-es "^4.17.21"
     mnemonist "^0.39.8"
     p-map "^4.0.0"
     shallow-clone "^3.0.1"
@@ -941,6 +948,16 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@ts-morph/common@~0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.19.0.tgz#927fcd81d1bbc09c89c4a310a84577fb55f3694e"
+  integrity sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==
+  dependencies:
+    fast-glob "^3.2.12"
+    minimatch "^7.4.3"
+    mkdirp "^2.1.6"
+    path-browserify "^1.0.1"
 
 "@turf/bbox-polygon@^6.4.0":
   version "6.5.0"
@@ -1316,7 +1333,14 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.202":
+"@types/lodash-es@^4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
   version "4.17.7"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.7.tgz#2f776bcb53adc9e13b2c0dfd493dfcbd7de43612"
   integrity sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==
@@ -2147,6 +2171,11 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
+code-block-writer@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-12.0.0.tgz#4dd58946eb4234105aff7f0035977b2afdc2a770"
+  integrity sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==
+
 codecov@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.8.3.tgz#9c3e364b8a700c597346ae98418d09880a3fdbe7"
@@ -2198,6 +2227,11 @@ commander@2, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3163,7 +3197,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.0.3, fast-glob@^3.2.9:
+fast-glob@^3.0.3, fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -4921,6 +4955,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -5082,6 +5121,13 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^7.4.3:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
+  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^9.0.3:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
@@ -5118,6 +5164,11 @@ mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mkdirp@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.1.6.tgz#964fbcb12b2d8c5d6fbc62a963ac95a273e2cc19"
+  integrity sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==
 
 mnemonist@^0.39.8:
   version "0.39.8"
@@ -5474,6 +5525,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -5524,6 +5580,15 @@ pbf@^3.2.1:
   dependencies:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"
+
+peggy@~4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/peggy/-/peggy-4.0.3.tgz#7bcd47718483ab405c960350c5250e3e487dec74"
+  integrity sha512-v7/Pt6kGYsfXsCrfb52q7/yg5jaAwiVaUMAPLPvy4DJJU6Wwr72t6nDIqIDkGfzd1B4zeVuTnQT0RGeOhe/uSA==
+  dependencies:
+    "@peggyjs/from-mem" "1.3.0"
+    commander "^12.1.0"
+    source-map-generator "0.8.0"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -5598,6 +5663,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
@@ -6014,6 +6084,13 @@ seek-bzip@^1.0.5:
   dependencies:
     commander "^2.8.1"
 
+semver@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -6195,6 +6272,11 @@ sort-package-json@~1.57.0:
     globby "10.0.0"
     is-plain-obj "2.1.0"
     sort-object-keys "^1.1.3"
+
+source-map-generator@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/source-map-generator/-/source-map-generator-0.8.0.tgz#10d5ca0651e2c9302ea338739cbd4408849c5d00"
+  integrity sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -6482,12 +6564,12 @@ teeny-request@7.1.1:
     stream-events "^1.0.5"
     uuid "^8.0.0"
 
-teraslice-test-harness@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-1.1.0.tgz#9d443585b048eacb492584c9e50242196bfc9e2a"
-  integrity sha512-1QvFlG//Atyar3tEIjC3PbfT0QvMkg8I+a7h7CJikVFpEGJLm9eIiiohmaD5fGaFXGNfqKElbDek3jPZwXHRww==
+teraslice-test-harness@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/teraslice-test-harness/-/teraslice-test-harness-1.2.0.tgz#7d284cfe2b52488de9834245a168b21709a838fa"
+  integrity sha512-lbkQs0ZkARg5K5+/NJxWL5CKReibs0Yp0MINnvIDPqhK4NuRkf3dBMX1C+ofRFj8p0yxlc1mtqao0pNNQ8PXbw==
   dependencies:
-    "@terascope/fetch-github-release" "^0.8.10"
+    "@terascope/fetch-github-release" "^1.0.0"
     decompress "^4.2.1"
     fs-extra "^11.2.0"
 
@@ -6580,14 +6662,30 @@ ts-jest@^29.2.4:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-ts-transforms@^0.86.1:
-  version "0.86.1"
-  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-0.86.1.tgz#9d7e88f4f43e181cd9199f6ef2485ddb16c125c9"
-  integrity sha512-v9uRhjG6Eer/8SJUu7uDpoHCLZAUS/pIRL0e7ogChR+0E6ybD/Ig/RmoIhXA1b8uMivAXaaKByqarfat4ClTcw==
+ts-morph@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-18.0.0.tgz#b9e7a898ea115064585a8a775d86da6edc9c5b4e"
+  integrity sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==
   dependencies:
-    "@terascope/data-mate" "^0.57.1"
-    "@terascope/types" "^0.18.0"
-    "@terascope/utils" "^0.60.0"
+    "@ts-morph/common" "~0.19.0"
+    code-block-writer "^12.0.0"
+
+ts-pegjs@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ts-pegjs/-/ts-pegjs-4.2.1.tgz#2993ce4cb91906580fe0b3b7ca6bc3a79fe628c4"
+  integrity sha512-mK/O2pu6lzWUeKpEMA/wsa0GdYblfjJI1y0s0GqH6xCTvugQDOWPJbm5rY6AHivpZICuXIriCb+a7Cflbdtc2w==
+  dependencies:
+    prettier "^2.8.8"
+    ts-morph "^18.0.0"
+
+ts-transforms@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-1.0.3.tgz#4f643d4b9a3dea3f0344301d59a03e5c4327fa65"
+  integrity sha512-z9XwXKHwCeJU7QUSPmaeP4L4AHZLBADH11roxQpBayHwp0xdlvwk2+C0gYWMZxHzQBgptRdXdx6/nSATegX1ag==
+  dependencies:
+    "@terascope/data-mate" "^1.0.3"
+    "@terascope/types" "^1.0.0"
+    "@terascope/utils" "^1.0.0"
     awesome-phonenumber "^2.70.0"
     graphlib "^2.1.8"
     is-ip "^3.1.0"
@@ -6981,13 +7079,15 @@ ws@^8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-xlucene-parser@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-0.59.0.tgz#f5a46a6b6b7d2453a825d6020f126d8d859ecd76"
-  integrity sha512-Bbes4QQIKCq2c1dcSXx0RuItPKv5fzAI2bTbRc4MfpCFRTPrZe5gHfn3bhMJaO2yr53F0WLvF8/s+KUyi831lw==
+xlucene-parser@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-1.0.2.tgz#741e2fd62b37927eb1895cfbd82d11cba16ba6bb"
+  integrity sha512-AC2NH3aqLriv/GGClRY37/Rt8KBe6JU8dFK2sZNsaVsLZWBypEJJzMfqdGChF8SHDw2iAswfLxOFVu+FBDcCnQ==
   dependencies:
-    "@terascope/types" "^0.18.0"
-    "@terascope/utils" "^0.60.0"
+    "@terascope/types" "^1.0.0"
+    "@terascope/utils" "^1.0.0"
+    peggy "~4.0.3"
+    ts-pegjs "^4.2.1"
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
This PR makes the following changes:
- bump standard-assets from 1.0.0 to 1.0.1
- bump standard-asset-apis from 0.7.2 to 1.0.0 ( this should have been done when we updated to ESM)
- update job-components from 1.1.0 to 1.2.0
- update utils from 0.60.0 to 1.0.0
- update ts-transforms from 0.86.1 to 1.0.3
- update scripts from 0.83.3 to 1.0.0
- update teraslice-test-harness from 1.1.0 to 1.2.0