### PR TITLE
udpate workflow hash

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f5e098fa861fe7744fa61842e82124f806364be9
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/asset-test.yml@f5e098fa861fe7744fa61842e82124f806364be9
+    uses: terascope/workflows/.github/workflows/asset-test.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
     secrets: inherit


### PR DESCRIPTION
This PR updates the github workflows hash to incorporate a fix for the upload-artifact@v4 action during build-and-publish-asset.yml workflow