### PR TITLE
Bundles dependency updates

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,9 +22,9 @@
     },
     "dependencies": {
         "@faker-js/faker": "^9.0.3",
-        "@terascope/job-components": "^1.4.0",
+        "@terascope/job-components": "^1.5.0",
         "@terascope/standard-asset-apis": "^1.0.2",
-        "@terascope/utils": "^1.1.0",
+        "@terascope/utils": "^1.3.0",
         "@types/chance": "^1.1.4",
         "@types/express": "^4.17.19",
         "chance": "^1.1.12",
@@ -34,7 +34,7 @@
         "randexp": "^0.5.3",
         "short-unique-id": "^5.2.0",
         "timsort": "^0.3.0",
-        "ts-transforms": "^1.2.0",
+        "ts-transforms": "^1.3.0",
         "tslib": "^2.7.0"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^1.1.0",
-        "@terascope/job-components": "^1.4.0",
-        "@terascope/scripts": "^1.3.2",
+        "@terascope/job-components": "^1.5.0",
+        "@terascope/scripts": "^1.4.0",
         "@terascope/standard-asset-apis": "^1.0.2",
         "@types/express": "^4.17.19",
         "@types/jest": "^29.5.13",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,10 +22,10 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "^2.0.1",
-        "@terascope/utils": "^1.1.0"
+        "@terascope/utils": "^1.3.0"
     },
     "devDependencies": {
-        "@terascope/scripts": "^1.3.2",
+        "@terascope/scripts": "^1.4.0",
         "@types/jest": "^29.5.13",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",

--- a/test/count_by_field/processor-spec.ts
+++ b/test/count_by_field/processor-spec.ts
@@ -75,7 +75,8 @@ describe('count_by_field processor', () => {
             job_prom_metrics_enabled: testConfig.job_prom_metrics_enabled,
             job_prom_metrics_port: testConfig.job_prom_metrics_port,
             job_prom_metrics_add_default: testConfig.job_prom_metrics_add_default,
-            prom_metrics_display_url: harness.context.sysconfig.terafoundation.prom_metrics_display_url
+            prom_metrics_display_url:
+                harness.context.sysconfig.terafoundation.prom_metrics_display_url
         });
         await harness.initialize();
 

--- a/test/count_by_field/processor-spec.ts
+++ b/test/count_by_field/processor-spec.ts
@@ -75,6 +75,7 @@ describe('count_by_field processor', () => {
             job_prom_metrics_enabled: testConfig.job_prom_metrics_enabled,
             job_prom_metrics_port: testConfig.job_prom_metrics_port,
             job_prom_metrics_add_default: testConfig.job_prom_metrics_add_default,
+            prom_metrics_display_url: harness.context.sysconfig.terafoundation.prom_metrics_display_url
         });
         await harness.initialize();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,7 +255,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.8"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.16.3", "@babel/runtime@^7.21.0":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.16.3":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
   integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
@@ -818,18 +818,18 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terascope/data-mate@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-1.2.0.tgz#198cca66f6eedd45a77570c6c52c5f37dca9199e"
-  integrity sha512-m+Uiwt0lZ9gVA0z448y5/M/2Vx8QttLZ53kr9LfE999YFM4AjNreqpcO1xZPrFVQpFhLq2XHo6m4GtjBLNeeaw==
+"@terascope/data-mate@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-1.3.0.tgz#51901e179ed32f246a334698a2ddc5253198269d"
+  integrity sha512-GmNNbYGX/tSfwjqCFq5YuUMR9E57wt0719TpkRNzQkT/FWk7VKXCueV9LFSHfvHoDUfMPgC9IpIkacuW7TFUNg==
   dependencies:
-    "@terascope/data-types" "^1.2.0"
-    "@terascope/types" "^1.1.0"
-    "@terascope/utils" "^1.2.0"
+    "@terascope/data-types" "^1.3.0"
+    "@terascope/types" "^1.2.0"
+    "@terascope/utils" "^1.3.0"
     "@types/validator" "^13.12.2"
-    awesome-phonenumber "^2.70.0"
-    date-fns "^2.30.0"
-    ip-bigint "^3.0.3"
+    awesome-phonenumber "^7.2.0"
+    date-fns "^4.1.0"
+    ip-bigint "^8.2.0"
     ip6addr "^0.2.5"
     ipaddr.js "^2.2.0"
     is-cidr "^5.1.0"
@@ -840,15 +840,15 @@
     uuid "^10.0.0"
     valid-url "^1.0.9"
     validator "^13.12.0"
-    xlucene-parser "^1.2.0"
+    xlucene-parser "^1.3.0"
 
-"@terascope/data-types@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-1.2.0.tgz#25344fd3683e0151ee4bc053731e5df77e157ff5"
-  integrity sha512-v3zdri31Ax87W46Nr9YPSRoLeIfgkFOVnNe0aeGAgQRyn1KErGxa7qXJ1TYOeNyioVMEGgH9L0zC8wcns2aP/w==
+"@terascope/data-types@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-1.3.0.tgz#c1139712985d5e5cc1c4bdaa503a874e12f18c74"
+  integrity sha512-g7GnEMZH7zd/WPrh9K7v0wpVTnbh/aKTx9M5BOcBqlQ9roycwl+SToB6id3VILI+t4XumcAfj2QLSoYfl6wxIQ==
   dependencies:
-    "@terascope/types" "^1.1.0"
-    "@terascope/utils" "^1.2.0"
+    "@terascope/types" "^1.2.0"
+    "@terascope/utils" "^1.3.0"
     graphql "^16.9.0"
     lodash "^4.17.21"
     yargs "^17.7.2"
@@ -887,13 +887,13 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.4.0.tgz#366640a45d65a6101d260ace9ec1cb273996b9f0"
-  integrity sha512-NhGazc+7f8SLV4i5KWS2Pz2rTciYnmsL+icif5UHFhPXL3z5xxEzwABU9P+FcIwczmQDzimz0iU24qbQz9lw6Q==
+"@terascope/job-components@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.5.0.tgz#a2d89a6f3941c40d1ef7acb5d82ff236afc39a47"
+  integrity sha512-pYlNxuVqaOXURksSizCSCgrkftdQPhBGMfiGotXCljlz/QNHxUbowaMP2dtYWzONqj1YS4uqbdTWEBPJSdooIw==
   dependencies:
-    "@terascope/types" "^1.1.0"
-    "@terascope/utils" "^1.2.0"
+    "@terascope/types" "^1.2.0"
+    "@terascope/utils" "^1.3.0"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
@@ -902,13 +902,13 @@
     prom-client "^15.1.3"
     uuid "^10.0.0"
 
-"@terascope/scripts@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.3.2.tgz#fb29d2a5090d7682179bf14df830e13be4a8e6eb"
-  integrity sha512-YLPKX/qc+s0S6BzgBy6rIL9vFQoE04RJbi7iFCOx7xc5whtq2Gwbqej6M/+U+TtZDA8LbY1hjgFiyfHWnOLjUA==
+"@terascope/scripts@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.4.0.tgz#392a9b5ecccb2f4bee16f241552dc4391cf9a04d"
+  integrity sha512-hmOgeFor9f7njIvji1qBvqkSnUHA0hkrEuuUBiIo4K17F4ThFKqRfe0KdpLnVkbKzwm1FoIQddYDNVr1fHyuPA==
   dependencies:
     "@kubernetes/client-node" "^0.22.0"
-    "@terascope/utils" "^1.2.0"
+    "@terascope/utils" "^1.3.0"
     codecov "^3.8.3"
     execa "9.4.0"
     fs-extra "^11.2.0"
@@ -931,19 +931,19 @@
     typedoc-plugin-markdown "~4.0.3"
     yargs "^17.7.2"
 
-"@terascope/types@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-1.1.0.tgz#0c87a0340e45b2e387caab27017b8c1e3ea10028"
-  integrity sha512-bmPl5w/X4ZIcWK8uqqbCMRObd9QaR52/S9TTZbgQNQA3QNz5KH4/HuC1kNMwdzL7rGWKu7KsqSM2Q4yiPRqmXw==
+"@terascope/types@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@terascope/types/-/types-1.2.0.tgz#cbad101f0153698450d6e99be7bdac88b883b779"
+  integrity sha512-Bcl+ZZy7l9uifVNsIRBhcfAOiknHTOYYg1BCiAwy/Zy+iqG0Mk6K1gsKUdOhXMbn8txC66hy3/BmsTCHZZI8Bg==
   dependencies:
     prom-client "^15.1.3"
 
-"@terascope/utils@^1.1.0", "@terascope/utils@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.2.0.tgz#7b7994cb47e3f1adff8e8567ce1cb03855bf7e00"
-  integrity sha512-AGvzZMswtOJTq0BzNEEr8ry1XZHB06kCjCd59THa25MNYvIdo5G8aiGDoKT30lSwalCO76ntOVOY6XGEQOyQWg==
+"@terascope/utils@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.3.0.tgz#9ab248693983a832d1aff9a2e69136a549d4865c"
+  integrity sha512-1QYNjO1auuGnH0+OgYCd01Jdjz7TO3bSw486xgoIpH5264YwRsHXzaYFTYZ0r4GAbEg6bYk8Qu0Z+0/p9ueXxA==
   dependencies:
-    "@terascope/types" "^1.1.0"
+    "@terascope/types" "^1.2.0"
     "@turf/bbox" "^7.1.0"
     "@turf/bbox-polygon" "^7.1.0"
     "@turf/boolean-contains" "^7.1.0"
@@ -958,13 +958,13 @@
     "@turf/line-to-polygon" "^7.1.0"
     "@types/lodash-es" "^4.17.12"
     "@types/validator" "^13.12.2"
-    awesome-phonenumber "^2.70.0"
-    date-fns "^2.30.0"
-    date-fns-tz "^1.3.7"
+    awesome-phonenumber "^7.2.0"
+    date-fns "^4.1.0"
+    date-fns-tz "^3.2.0"
     datemath-parser "^1.0.6"
     debug "^4.3.7"
     geo-tz "^8.1.1"
-    ip-bigint "^3.0.3"
+    ip-bigint "^8.2.0"
     ip-cidr "^4.0.2"
     ip6addr "^0.2.5"
     ipaddr.js "^2.2.0"
@@ -1942,10 +1942,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-awesome-phonenumber@^2.70.0:
-  version "2.73.0"
-  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-2.73.0.tgz#c921f47450ba10bb2e4a6305cc85d802f57a96cf"
-  integrity sha512-zirkzWFUheNnnPY1QE05PQd+5drn+5kVy76gZ3WyXnLwzXOguw6sqksyZGO1qyNnYj3Y/SDITXnS/TCk/hJXpQ==
+awesome-phonenumber@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/awesome-phonenumber/-/awesome-phonenumber-7.2.0.tgz#009ec06cebfdf8a41b60cfb421ac2c842dbf3a35"
+  integrity sha512-CqH0TyDMHiMhqGRg/kaJDiV5KRok5AdrJKvUsED9/QRQdiCjUzp32+NqEEnY+OWEDTeeqlyLsLs7SLR/sPQU2A==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -2529,17 +2529,15 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns-tz@^1.3.7:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.8.tgz#083e3a4e1f19b7857fa0c18deea6c2bc46ded7b9"
-  integrity sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==
+date-fns-tz@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-3.2.0.tgz#647dc56d38ac33a3e37b65e9d5c4cda5af5e58e6"
+  integrity sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==
 
-date-fns@^2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 datemath-parser@^1.0.6:
   version "1.0.6"
@@ -4083,12 +4081,10 @@ ip-address@^9.0.5:
     jsbn "1.1.0"
     sprintf-js "^1.1.3"
 
-ip-bigint@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ip-bigint/-/ip-bigint-3.0.3.tgz#d9ecbf1d4894ccc965f93e5b7f4ac86d0c6e9d0c"
-  integrity sha512-hGCBH8QGndQsezHSJ+YYcl+L3DcvnSjYdHYuF801DO1pS5rzRlc95VplAFkgk7XaJBpkJQnHPQQBlVjGsj+uJg==
-  dependencies:
-    is-ip "3.1.0"
+ip-bigint@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/ip-bigint/-/ip-bigint-8.2.0.tgz#8b4c0ffe0d834edd61e34b6b72cf50b7946e12ff"
+  integrity sha512-46EAEKzGNxojH5JaGEeCix49tL4h1W8ia5mhogZ68HroVAfyLj1E+SFFid4GuyK0mdIKjwcAITLqwg1wlkx2iQ==
 
 ip-cidr@^4.0.2:
   version "4.0.2"
@@ -4096,11 +4092,6 @@ ip-cidr@^4.0.2:
   integrity sha512-KifhLKBjdS/hB3TD4UUOalVp1BpzPFvRpgJvXcP0Ya98tuSQTUQ71iI7EW7CKddkBJTYB3GfTWl5eJwpLOXj2A==
   dependencies:
     ip-address "^9.0.5"
-
-ip-regex@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
-  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ip-regex@^5.0.0:
   version "5.0.0"
@@ -4246,13 +4237,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-ip@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
-  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
-  dependencies:
-    ip-regex "^4.0.0"
 
 is-ip@^5.0.1:
   version "5.0.1"
@@ -6585,16 +6569,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6688,14 +6663,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6967,15 +6935,15 @@ ts-pegjs@^4.2.1:
     prettier "^2.8.8"
     ts-morph "^18.0.0"
 
-ts-transforms@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-1.2.0.tgz#3ad1ee29ec8c55b6449f85dd7e7cc39d469cb89a"
-  integrity sha512-1ULHCs2t8e6sDA7f298XcJ0ONfpDWjPa5zuE+1t+bYxSb/47kIxtR9rGZvPbz7Cj4eS+Z2aJI7MveG0nZlCj/g==
+ts-transforms@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-1.3.0.tgz#2e5435e13f0676122586f0b2808240d0cea2edb0"
+  integrity sha512-bqcHIUgU3tgZ16rR0eD3+f7dPAc3245CQhDvVWON+IESIOKHkU52sfs/Qi82Swb/PcvrEyb7nfK7qnBbZin0OQ==
   dependencies:
-    "@terascope/data-mate" "^1.2.0"
-    "@terascope/types" "^1.1.0"
-    "@terascope/utils" "^1.2.0"
-    awesome-phonenumber "^2.70.0"
+    "@terascope/data-mate" "^1.3.0"
+    "@terascope/types" "^1.2.0"
+    "@terascope/utils" "^1.3.0"
+    awesome-phonenumber "^7.2.0"
     graphlib "^2.1.8"
     is-ip "^5.0.1"
     jexl "^2.2.2"
@@ -7358,16 +7326,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7403,13 +7362,13 @@ ws@^8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-xlucene-parser@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-1.2.0.tgz#894e9f1c311b475352bb36805e1f9e3cf97e8d1d"
-  integrity sha512-uq/1v/0+g9N1GqmWbNKwFJW3nzGTHpRRzlbt42LCMCfbxorNI+a47Ujdx3h1TJkSWw/45vHowYE8a3kCB7X/6A==
+xlucene-parser@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-1.3.0.tgz#d7e394310de80f61cd06de51a9118e15034caaca"
+  integrity sha512-Vpa9QpNiQzCkiHA71OsQBpVluj6TZMe0fIzLnQ32CgmMRLKEOaQ6lvN24jRzP9doHm86mLzDtpaW6npLPo9bfw==
   dependencies:
-    "@terascope/types" "^1.1.0"
-    "@terascope/utils" "^1.2.0"
+    "@terascope/types" "^1.2.0"
+    "@terascope/utils" "^1.3.0"
     peggy "~4.0.3"
     ts-pegjs "^4.2.1"
 


### PR DESCRIPTION
This PR makes the following changes:
- bump job-components from 1.4.0 to 1.5.0
- bump scripts from 1.3.2 to 1.4.0
- bump ts-transforms from 1.2.0 to 1.3.0
- bump utils from 1.1.0 to 1.3.0
- change `test/count_by_field/processor-spec.ts` `promMetrics.init()` config to include required field `prom_metrics_display_url`