### PR TITLE
Bump job-components, fix assignment prom metric label

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@faker-js/faker": "^9.1.0",
-        "@terascope/job-components": "^1.5.1",
+        "@terascope/job-components": "^1.5.3",
         "@terascope/standard-asset-apis": "^1.0.2",
         "@terascope/utils": "^1.3.2",
         "@types/chance": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "^1.1.0",
-        "@terascope/job-components": "^1.5.1",
+        "@terascope/job-components": "^1.5.3",
         "@terascope/scripts": "^1.4.2",
         "@terascope/standard-asset-apis": "^1.0.2",
         "@types/express": "^4.17.19",

--- a/test/count_by_field/processor-spec.ts
+++ b/test/count_by_field/processor-spec.ts
@@ -76,7 +76,10 @@ describe('count_by_field processor', () => {
             job_prom_metrics_port: testConfig.job_prom_metrics_port,
             job_prom_metrics_add_default: testConfig.job_prom_metrics_add_default,
             prom_metrics_display_url:
-                harness.context.sysconfig.terafoundation.prom_metrics_display_url
+                harness.context.sysconfig.terafoundation.prom_metrics_display_url,
+            labels: {
+                assignment: 'worker'
+            }
         });
         await harness.initialize();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,13 +891,13 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.5.1.tgz#a36e8b3a94ed389e16117d7500cdd3bdcfc40f97"
-  integrity sha512-rMHF/mJbv1K5SyJWQ1N+yuK6icntu+kHPyxcdcEvQ9F4Ci4NjJn8zUKdE305Rpdmz2aTx0bDiCXGQNNwVO2sVQ==
+"@terascope/job-components@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.5.3.tgz#f8d180dd08b6fe955b4501ca96f2a629473a434f"
+  integrity sha512-H0OycdzTJTwLqoZBlT8q9xgiCk+NDs9ZtND6EpxRdiLBXDN3zmhnPPALHPLMO3Wz/DZU0Ip4AsKJ+jNOArOG9w==
   dependencies:
     "@terascope/types" "^1.2.0"
-    "@terascope/utils" "^1.3.1"
+    "@terascope/utils" "^1.3.2"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"
@@ -942,7 +942,7 @@
   dependencies:
     prom-client "^15.1.3"
 
-"@terascope/utils@^1.3.1", "@terascope/utils@^1.3.2":
+"@terascope/utils@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.3.2.tgz#c9f22523a1dc0d578c1c3428303f0f2076edbf69"
   integrity sha512-HNnZtkwQjOyH907lt4wX1avNtyyE1anXzvbBTc9YuX9SPVbeff92+mjYL+6qWtuv/TiHlKBT77+F1i5eB8WEuA==
@@ -6536,16 +6536,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6639,14 +6630,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7292,16 +7276,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR makes the following changes:
- bump job-components from 1.5.1 to 1.5.3
- The default label `assignment` was removed from `promMetrics` API, so it needed to be added to `initConfig.labels` object within tests.