### PR TITLE
Bump version for release

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {
@@ -24,7 +24,7 @@
         "@faker-js/faker": "~9.3.0",
         "@terascope/data-mate": "~1.4.2",
         "@terascope/job-components": "~1.6.2",
-        "@terascope/standard-asset-apis": "~1.0.2",
+        "@terascope/standard-asset-apis": "~1.0.3",
         "@terascope/teraslice-state-storage": "~1.4.1",
         "@terascope/utils": "~1.4.1",
         "@types/chance": "~1.1.4",
@@ -40,12 +40,12 @@
         "ts-transforms": "~1.4.2",
         "tslib": "~2.8.1"
     },
+    "devDependencies": {
+        "@types/ms": "^0.7.34"
+    },
     "engines": {
         "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
-    "terascope": {},
-    "devDependencies": {
-        "@types/ms": "^0.7.34"
-    }
+    "terascope": {}
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "type": "module",
@@ -32,7 +32,7 @@
         "@terascope/eslint-config": "~1.1.2",
         "@terascope/job-components": "~1.6.2",
         "@terascope/scripts": "~1.5.3",
-        "@terascope/standard-asset-apis": "~1.0.2",
+        "@terascope/standard-asset-apis": "~1.0.3",
         "@types/express": "~4.17.19",
         "@types/jest": "~29.5.14",
         "@types/json2csv": "~5.0.7",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/standard-asset-apis",
     "displayName": "Standard Asset Apis",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "A common set of tools for data processing",
     "homepage": "https://github.com/terascope/standard-assets",
     "repository": "git@github.com:terascope/standard-assets.git",


### PR DESCRIPTION
This PR makes the following changes:
- bump standard-asset-apis from v1.0.2 to v1.03
- bump standard-assets from v1.2.0 to v1.3.0