### PR TITLE
bundled dependency updates

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,11 +22,11 @@
     },
     "dependencies": {
         "@faker-js/faker": "~9.3.0",
-        "@terascope/data-mate": "~1.5.0",
-        "@terascope/job-components": "~1.7.0",
+        "@terascope/data-mate": "~1.6.0",
+        "@terascope/job-components": "~1.8.0",
         "@terascope/standard-asset-apis": "~1.0.3",
-        "@terascope/teraslice-state-storage": "~1.5.0",
-        "@terascope/utils": "~1.5.0",
+        "@terascope/teraslice-state-storage": "~1.6.0",
+        "@terascope/utils": "~1.6.0",
         "@types/chance": "~1.1.4",
         "@types/express": "~4.17.19",
         "chance": "~1.1.12",
@@ -37,7 +37,7 @@
         "randexp": "~0.5.3",
         "short-unique-id": "~5.2.0",
         "timsort": "~0.3.0",
-        "ts-transforms": "~1.5.0",
+        "ts-transforms": "~1.6.0",
         "tslib": "~2.8.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     },
     "devDependencies": {
         "@terascope/eslint-config": "~1.1.3",
-        "@terascope/job-components": "~1.7.0",
-        "@terascope/scripts": "~1.6.0",
+        "@terascope/job-components": "~1.8.0",
+        "@terascope/scripts": "~1.7.1",
         "@terascope/standard-asset-apis": "~1.0.3",
         "@types/express": "~4.17.19",
         "@types/jest": "~29.5.14",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,10 +22,10 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "~3.1.0",
-        "@terascope/utils": "~1.5.0"
+        "@terascope/utils": "~1.6.0"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.6.0",
+        "@terascope/scripts": "~1.7.1",
         "@types/jest": "~29.5.14",
         "@types/node": "~22.10.2",
         "jest": "~29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,14 +836,14 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@terascope/data-mate@~1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-1.5.0.tgz#e2bea2027be7c54948022ffb6a7f7a942ecab02f"
-  integrity sha512-gAx+GQOq93ZDzUI7wBOJ0ifpUuMhb8p1fXhEzHQ55AmjglA/2K2TLiGXDaAqxc353YrDWH3Z843gMXdzxci0VA==
+"@terascope/data-mate@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-mate/-/data-mate-1.6.0.tgz#b62696ddd96d7c6ccde63b3607ffaad7bb0393c7"
+  integrity sha512-kwozz75nnYoNUkOdPcRO1xKDIlThC2/IGNjUvDhiD5tAXZdtSFhakAWtOdqqxFnkgOx0BspS8B0rtjpOgIf5Ow==
   dependencies:
-    "@terascope/data-types" "~1.5.0"
+    "@terascope/data-types" "~1.6.0"
     "@terascope/types" "~1.3.1"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     "@types/validator" "~13.12.2"
     awesome-phonenumber "~7.2.0"
     date-fns "~4.1.0"
@@ -856,25 +856,25 @@
     uuid "~11.0.3"
     valid-url "~1.0.9"
     validator "~13.12.0"
-    xlucene-parser "~1.5.0"
+    xlucene-parser "~1.6.0"
 
-"@terascope/data-types@~1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-1.5.0.tgz#3621d32cba7cd7bfb3f3c9bd884d7acbf24b13d2"
-  integrity sha512-PAUxJVS2dZGbGIgdN/qoS8UAzTOmko2JWgh/6glN1lB1zlp0RbBTs4kX9+waYde6A8KhnXw+PbqbSyO9PbF81Q==
+"@terascope/data-types@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@terascope/data-types/-/data-types-1.6.0.tgz#9c45878a1bc0c7f45ca7ee43676d2ee55c338e8e"
+  integrity sha512-Wmkj0dyi5WKJ+otmNdodr2AgJZhh4gOb6I4Tx2h3C0VzxvNwaf+yKPt7+YuK79AnS/Sswdgp58dM3/hALs5NLg==
   dependencies:
     "@terascope/types" "~1.3.1"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     graphql "~16.9.0"
     yargs "~17.7.2"
 
-"@terascope/elasticsearch-api@~4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@terascope/elasticsearch-api/-/elasticsearch-api-4.5.0.tgz#0da5e61476c567c8a65a7ee5d5092ac323d24786"
-  integrity sha512-wtDB0kXi6Gwqze0oIJJUoJd9eye6fcNMZ3eZVc/gK934hirgyjTMkVBfPLqhEghZEGsjtm4GQ1TUI2bStdM8VQ==
+"@terascope/elasticsearch-api@~4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@terascope/elasticsearch-api/-/elasticsearch-api-4.6.0.tgz#374899b67ff9349f61cedfbc630f500071a590da"
+  integrity sha512-Mu1B461wIe+3MucQ4MahN2SC7nNJtWkUt5ciuQRApTU7CaTi97YmVdvzZifCnynJcZuBR25kWj6Njcoj8tHFSA==
   dependencies:
     "@terascope/types" "~1.3.1"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     bluebird "~3.7.2"
     setimmediate "~1.0.5"
 
@@ -912,13 +912,13 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@~1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.7.0.tgz#ed9918b0d44f801eb51b1325dd656fac61778002"
-  integrity sha512-bQNuV11FJdjFl9EWAiOxKcgbD3I2staJHSpwYh2IHDsVwNxAW1zcMS6f8P1cX3rgw2gOJb91vzGKd4eOZ3CuYQ==
+"@terascope/job-components@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-1.8.0.tgz#41423e1bc5cbada05bcfff572d7df4f85b49d381"
+  integrity sha512-1m3iT5tSDWt9m1YC2cDlEzF/skDdRAkgIGX/BttuElZo57/iu51T2dnzf3Yt/h6G45rBNGymT0ZsmYxPs3UoGQ==
   dependencies:
     "@terascope/types" "~1.3.1"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     convict "~6.2.4"
     convict-format-with-moment "~6.2.0"
     convict-format-with-validator "~6.2.0"
@@ -927,13 +927,13 @@
     prom-client "~15.1.3"
     uuid "~11.0.3"
 
-"@terascope/scripts@~1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.6.0.tgz#a216cb170725359b123b9019c7e4262ed946f3b9"
-  integrity sha512-ibuc1v88ZH4OC6GBTmNO8vccwSwPvRFsbeYvEusTkVUYV9jhFma9FPw/b1X6Gf+NYR4+N/JaWPIgHtcmoViURg==
+"@terascope/scripts@~1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@terascope/scripts/-/scripts-1.7.1.tgz#0f0fd2b6871ac15d8622ad23885f18c0c86db883"
+  integrity sha512-O4ztln3qYeRge3z3BGPIeAcUgvApU25lyQSzOTU6pQLTxIXvSSq7y5NWeghkrshJMjxjOXOLZMjD4M7SJTwxfQ==
   dependencies:
     "@kubernetes/client-node" "~0.22.3"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     codecov "~3.8.3"
     execa "~9.5.2"
     fs-extra "~11.2.0"
@@ -955,13 +955,13 @@
     typedoc-plugin-markdown "~4.0.3"
     yargs "~17.7.2"
 
-"@terascope/teraslice-state-storage@~1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@terascope/teraslice-state-storage/-/teraslice-state-storage-1.5.0.tgz#9830cfdd1fc879463210498ece5c181df0ee3603"
-  integrity sha512-kYAbkoAxOz/WSt3MHEohAjQzRt3IV5e12kMZg8lFVOZvwy/xdnFDMJvJ0dvwSXzMoiUO217TbCPu+WjY881xgQ==
+"@terascope/teraslice-state-storage@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@terascope/teraslice-state-storage/-/teraslice-state-storage-1.6.0.tgz#ad959acd34cbb45170680e25316d1a58b788b233"
+  integrity sha512-UpJXbo4Arkxm5IL1HBKG/MiC8tYkNvZVxHdT9mGmJSAW/dDDtw9/wgeVJbcB3azYAvN82vtaoZHgH3e32YI0sA==
   dependencies:
-    "@terascope/elasticsearch-api" "~4.5.0"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/elasticsearch-api" "~4.6.0"
+    "@terascope/utils" "~1.6.0"
 
 "@terascope/types@~1.3.1":
   version "1.3.1"
@@ -970,10 +970,10 @@
   dependencies:
     prom-client "~15.1.3"
 
-"@terascope/utils@~1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.5.0.tgz#b490a25b4670d7755323d3650a761f814e97fb8b"
-  integrity sha512-m1IBEB1Dh9SBBL//jlh9jeCSaxCQ4PGcdzNncBT5KPVnhDZoM/KgNOthB2TDtNJ+goZZjzhjaR4KVvY1Eljfzw==
+"@terascope/utils@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@terascope/utils/-/utils-1.6.0.tgz#ff0d5a2f264403bf9901086071552d94b53398aa"
+  integrity sha512-qL+zZjKbQZhriKIX/Yu7E4wBaqFvWDWX0xX/E9TqrASqcTBBY1X+kRHhEz5q4No9RSdwJiDFIA0zAqadbkbBQA==
   dependencies:
     "@chainsafe/is-ip" "~2.0.2"
     "@terascope/types" "~1.3.1"
@@ -6810,14 +6810,14 @@ ts-pegjs@~4.2.1:
     prettier "^2.8.8"
     ts-morph "^18.0.0"
 
-ts-transforms@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-1.5.0.tgz#73936374b283edb1fee44241ccf92f5f91aaaf69"
-  integrity sha512-nS7TDRe0Xd9d7N08AHPvFgr7ElqQXyqUm6N0rf69P5JaAtuTWdPkdA9t270bkfOi+pWOccLJFI7E/IBytBJjSw==
+ts-transforms@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ts-transforms/-/ts-transforms-1.6.0.tgz#04df301355e748e45594de660c341bd62d973c5f"
+  integrity sha512-5pbFfMHewKD3/WiXTM1/UUT9w9J3ZUNUkebh8RFlf7AAZbqAbYijeZ6KXP80chsmhxcecY2rXvI9vgMU0jxmqw==
   dependencies:
-    "@terascope/data-mate" "~1.5.0"
+    "@terascope/data-mate" "~1.6.0"
     "@terascope/types" "~1.3.1"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     awesome-phonenumber "~7.2.0"
     graphlib "~2.1.8"
     jexl "~2.3.0"
@@ -7224,13 +7224,13 @@ ws@^8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-xlucene-parser@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-1.5.0.tgz#155435b0c2c413f14a9df4f2fde02ca51ef910f4"
-  integrity sha512-rMpHORzeNEztmX2gJTlR0uJ7dw6qMjWjK43xYdOOwURRqXLYBqiFg3EFGyeQY+IZjE6s7iKiVAcVwp067ac+Yw==
+xlucene-parser@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/xlucene-parser/-/xlucene-parser-1.6.0.tgz#14ee0aa5270d107a4affb9e4b58c5e25e55fcc96"
+  integrity sha512-DX1wZSKAzarGB7nfR+4UrKjhwRukIXDnB9OkTgm3rkl+tzwOXL4x5H3UvmYsLYgDOXqMLAQj9xPwHha9qLonhg==
   dependencies:
     "@terascope/types" "~1.3.1"
-    "@terascope/utils" "~1.5.0"
+    "@terascope/utils" "~1.6.0"
     peggy "~4.2.0"
     ts-pegjs "~4.2.1"
 


### PR DESCRIPTION
This PR makes the following dependency updates:
- standard asset
  - dependencies
    - @terascope/data-mate from 1.5.0 to 1.6.0
    - @terascope/job-components from 1.7.0 to 1.8.0
    - @terascope/teraslice-state-storage from 1.5.0 to 1.6.0
    - @terascope/utils from 1.5.0 to 1.6.0
    - ts-transforms from 1.5.0 to 1.6.0
- standard-asset-apis
  - dependencies
    - @terascope/utils from 1.5.0 to 1.6.0 
  - devDependencies
    - @terascope/scripts from 1.6.0 to 1.7.1
- workspace
  - devDependencies
    - @terascope/scripts from 1.6.0 to 1.7.1
    - @terascope/job-components from 1.7.0 to 1.8.0