### PR TITLE
bundled dependency updates

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,11 +22,11 @@
     },
     "dependencies": {
         "@faker-js/faker": "~9.3.0",
-        "@terascope/data-mate": "~1.6.0",
-        "@terascope/job-components": "~1.8.0",
+        "@terascope/data-mate": "~1.7.2",
+        "@terascope/job-components": "~1.9.1",
         "@terascope/standard-asset-apis": "~1.0.3",
-        "@terascope/teraslice-state-storage": "~1.6.0",
-        "@terascope/utils": "~1.6.0",
+        "@terascope/teraslice-state-storage": "~1.7.1",
+        "@terascope/utils": "~1.7.1",
         "@types/chance": "~1.1.4",
         "@types/express": "~4.17.19",
         "chance": "~1.1.12",
@@ -37,7 +37,7 @@
         "randexp": "~0.5.3",
         "short-unique-id": "~5.2.0",
         "timsort": "~0.3.0",
-        "ts-transforms": "~1.6.0",
+        "ts-transforms": "~1.7.2",
         "tslib": "~2.8.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,24 +29,24 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.3",
-        "@terascope/job-components": "~1.8.0",
-        "@terascope/scripts": "~1.7.1",
+        "@terascope/eslint-config": "~1.1.4",
+        "@terascope/job-components": "~1.9.1",
+        "@terascope/scripts": "~1.9.0",
         "@terascope/standard-asset-apis": "~1.0.3",
         "@types/express": "~4.17.19",
         "@types/jest": "~29.5.14",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~22.10.2",
+        "@types/node": "~22.10.6",
         "@types/node-gzip": "~1.1.0",
         "@types/timsort": "~0.3.0",
-        "eslint": "~9.17.0",
+        "eslint": "~9.18.0",
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
         "node-notifier": "~10.0.1",
-        "teraslice-test-harness": "~1.2.1",
+        "teraslice-test-harness": "~1.3.1",
         "ts-jest": "~29.2.5",
         "tslib": "~2.8.1",
-        "typescript": "~5.2.2"
+        "typescript": "~5.7.3"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,12 +22,12 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "~3.1.0",
-        "@terascope/utils": "~1.6.0"
+        "@terascope/utils": "~1.7.1"
     },
     "devDependencies": {
-        "@terascope/scripts": "^1.9.0",
+        "@terascope/scripts": "~1.9.0",
         "@types/jest": "~29.5.14",
-        "@types/node": "~22.10.2",
+        "@types/node": "~22.10.6",
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
         "jest-fixtures": "~0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@eslint/core@npm:0.10.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/074018075079b3ed1f14fab9d116f11a8824cdfae3e822badf7ad546962fafe717a31e61459bad8cc59cf7070dc413ea9064ddb75c114f05b05921029cde0a64
+  languageName: node
+  linkType: hard
+
 "@eslint/core@npm:^0.9.0":
   version: 0.9.0
   resolution: "@eslint/core@npm:0.9.0"
@@ -503,10 +512,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.17.0":
-  version: 9.17.0
-  resolution: "@eslint/js@npm:9.17.0"
-  checksum: 10c0/a0fda8657a01c60aa540f95397754267ba640ffb126e011b97fd65c322a94969d161beeaef57c1441c495da2f31167c34bd38209f7c146c7225072378c3a933d
+"@eslint/js@npm:9.18.0":
+  version: 9.18.0
+  resolution: "@eslint/js@npm:9.18.0"
+  checksum: 10c0/3938344c5ac7feef4b73fcb30f3c3e753570cea74c24904bb5d07e9c42fcd34fcbc40f545b081356a299e11f360c9c274b348c05fb0113fc3d492e5175eee140
   languageName: node
   linkType: hard
 
@@ -523,6 +532,16 @@ __metadata:
   dependencies:
     levn: "npm:^0.4.1"
   checksum: 10c0/89a8035976bb1780e3fa8ffe682df013bd25f7d102d991cecd3b7c297f4ce8c1a1b6805e76dd16465b5353455b670b545eff2b4ec3133e0eab81a5f9e99bd90f
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@eslint/plugin-kit@npm:0.2.5"
+  dependencies:
+    "@eslint/core": "npm:^0.10.0"
+    levn: "npm:^0.4.1"
+  checksum: 10c0/ba9832b8409af618cf61791805fe201dd62f3c82c783adfcec0f5cd391e68b40beaecb47b9a3209e926dbcab65135f410cae405b69a559197795793399f61176
   languageName: node
   linkType: hard
 
@@ -1132,13 +1151,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "@terascope/data-mate@npm:1.6.0"
+"@terascope/data-mate@npm:~1.7.2":
+  version: 1.7.2
+  resolution: "@terascope/data-mate@npm:1.7.2"
   dependencies:
-    "@terascope/data-types": "npm:~1.6.0"
-    "@terascope/types": "npm:~1.3.1"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/data-types": "npm:~1.7.1"
+    "@terascope/types": "npm:~1.4.1"
+    "@terascope/utils": "npm:~1.7.1"
     "@types/validator": "npm:~13.12.2"
     awesome-phonenumber: "npm:~7.2.0"
     date-fns: "npm:~4.1.0"
@@ -1151,40 +1170,40 @@ __metadata:
     uuid: "npm:~11.0.3"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.6.0"
-  checksum: 10c0/72eaf919c6afc81def0c3d6c1ae46466d3de9ba02653b773e72dc1657a1b6918d7bbd960d42d2b47dbe0498b0cb0c4557ed94e07feebf7ce5c636099db914747
+    xlucene-parser: "npm:~1.7.2"
+  checksum: 10c0/86cf5b34dc48190d331a1875a5285bc4d8f6789b5b98ddd541d3468c22168f56e7f97fd0553219bf34798de9eaf25a8f49ee0bd539bda040fe081e2b6e72c318
   languageName: node
   linkType: hard
 
-"@terascope/data-types@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "@terascope/data-types@npm:1.6.0"
+"@terascope/data-types@npm:~1.7.1":
+  version: 1.7.1
+  resolution: "@terascope/data-types@npm:1.7.1"
   dependencies:
-    "@terascope/types": "npm:~1.3.1"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/types": "npm:~1.4.1"
+    "@terascope/utils": "npm:~1.7.1"
     graphql: "npm:~16.9.0"
     yargs: "npm:~17.7.2"
   bin:
-    data-types: bin/data-types.js
-  checksum: 10c0/415f01f1678f13b769a36f149a4d2f64753feb152c4ae46b4083c41eb94a9938956130b2deba8aa4d3843b6eea8b689a949f006fe0cb2d9e1a74cff0471ae744
+    data-types: ./bin/data-types.js
+  checksum: 10c0/1c5a85422fb59bfb42b47640e01aa2312b7737256b4846b51b015eb2c10e2817364bf3ca9c1da506e73422981c04c4405ca79956df48213685cc1965b868af67
   languageName: node
   linkType: hard
 
-"@terascope/elasticsearch-api@npm:~4.6.0":
-  version: 4.6.0
-  resolution: "@terascope/elasticsearch-api@npm:4.6.0"
+"@terascope/elasticsearch-api@npm:~4.7.1":
+  version: 4.7.1
+  resolution: "@terascope/elasticsearch-api@npm:4.7.1"
   dependencies:
-    "@terascope/types": "npm:~1.3.1"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/types": "npm:~1.4.1"
+    "@terascope/utils": "npm:~1.7.1"
     bluebird: "npm:~3.7.2"
     setimmediate: "npm:~1.0.5"
-  checksum: 10c0/f786f6264c19c5990014b44c41af776c1f1ce52928dec51ea90c242b28e04a61a10d3b06dc6f198f9f305e43fe479e2318ab88352d91ed62da884dcf87d10c45
+  checksum: 10c0/4d877de112adb55a3e7bde09bd136e317bbaa7b78da0bc25df3d9d729e4674c58c64a97a2e5704b93137084fec1d6f10799a7cf8efe6587bb2b1237c53112cfa
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.3":
-  version: 1.1.3
-  resolution: "@terascope/eslint-config@npm:1.1.3"
+"@terascope/eslint-config@npm:~1.1.4":
+  version: 1.1.4
+  resolution: "@terascope/eslint-config@npm:1.1.4"
   dependencies:
     "@eslint/compat": "npm:~1.2.4"
     "@eslint/js": "npm:~9.16.0"
@@ -1201,9 +1220,9 @@ __metadata:
     eslint-plugin-react-hooks: "npm:~5.1.0"
     eslint-plugin-testing-library: "npm:~7.1.1"
     globals: "npm:~15.13.0"
-    typescript: "npm:~5.2.2"
+    typescript: "npm:~5.7.2"
     typescript-eslint: "npm:~8.18.0"
-  checksum: 10c0/f77d843e8f228d953f60636fa8b88dad26ca6a293fb8a51dcc14e9a2e2c0aabe7fe8c349b11e688e298f7030b833cfad4a3b3af96f2eb46d51dd2f20ab4befe2
+  checksum: 10c0/381dd7d8df613a09567ebc4e44845cd90e4000411b86546cc9d1cc2b1d33b02396205a918b61ed86ad758bea5195db64b73b24c2269febe3b6e7f46ee3f627d4
   languageName: node
   linkType: hard
 
@@ -1222,24 +1241,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.8.0":
-  version: 1.8.0
-  resolution: "@terascope/job-components@npm:1.8.0"
+"@terascope/job-components@npm:~1.9.1":
+  version: 1.9.1
+  resolution: "@terascope/job-components@npm:1.9.1"
   dependencies:
-    "@terascope/types": "npm:~1.3.1"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/types": "npm:~1.4.1"
+    "@terascope/utils": "npm:~1.7.1"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     datemath-parser: "npm:~1.0.6"
     import-meta-resolve: "npm:~4.1.0"
     prom-client: "npm:~15.1.3"
+    semver: "npm:~7.6.3"
     uuid: "npm:~11.0.3"
-  checksum: 10c0/6c30d35a95234839a0e2f62c3ef454b843bb78fcdaf9dce1464264b927df62a0dfe5a8ad58a00d457f9c6b886aba3fb4b2da99d01994de95a4b3add836538bcb
+  checksum: 10c0/5a598839217b5211b69a63f4550e741bf16b34a973c5bff2a3e154e6e823f6257c76c14e310119d7731ca6957e34cb6ff6068d84ed7f3467b2aca4bbe26e5f2f
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:^1.9.0":
+"@terascope/scripts@npm:~1.9.0":
   version: 1.9.0
   resolution: "@terascope/scripts@npm:1.9.0"
   dependencies:
@@ -1276,52 +1296,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.7.1":
-  version: 1.7.1
-  resolution: "@terascope/scripts@npm:1.7.1"
-  dependencies:
-    "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.6.0"
-    codecov: "npm:~3.8.3"
-    execa: "npm:~9.5.2"
-    fs-extra: "npm:~11.2.0"
-    globby: "npm:~14.0.2"
-    got: "npm:~13.0.0"
-    ip: "npm:~2.0.1"
-    js-yaml: "npm:~4.1.0"
-    kafkajs: "npm:~2.2.4"
-    micromatch: "npm:~4.0.8"
-    mnemonist: "npm:~0.39.8"
-    ms: "npm:~2.1.3"
-    package-json: "npm:~10.0.1"
-    package-up: "npm:~5.0.0"
-    semver: "npm:~7.6.3"
-    signale: "npm:~1.4.0"
-    sort-package-json: "npm:~2.12.0"
-    toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.25.13"
-    typedoc-plugin-markdown: "npm:~4.0.3"
-    yargs: "npm:~17.7.2"
-  peerDependencies:
-    typescript: ~5.2.2
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    ts-scripts: bin/ts-scripts.js
-  checksum: 10c0/807ce083c5f66f085a10337dbc429e604552a2e216668caf9125997fa0dc4a04660f2d19ece6912bcd8217168c9f789bc1461b720c7ab40aa3dd111382ab2db6
-  languageName: node
-  linkType: hard
-
 "@terascope/standard-asset-apis@npm:~1.0.3, @terascope/standard-asset-apis@workspace:packages/standard-asset-apis":
   version: 0.0.0-use.local
   resolution: "@terascope/standard-asset-apis@workspace:packages/standard-asset-apis"
   dependencies:
     "@sindresorhus/fnv1a": "npm:~3.1.0"
-    "@terascope/scripts": "npm:^1.9.0"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/scripts": "npm:~1.9.0"
+    "@terascope/utils": "npm:~1.7.1"
     "@types/jest": "npm:~29.5.14"
-    "@types/node": "npm:~22.10.2"
+    "@types/node": "npm:~22.10.6"
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
     jest-fixtures: "npm:~0.6.0"
@@ -1329,22 +1312,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-state-storage@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "@terascope/teraslice-state-storage@npm:1.6.0"
+"@terascope/teraslice-state-storage@npm:~1.7.1":
+  version: 1.7.1
+  resolution: "@terascope/teraslice-state-storage@npm:1.7.1"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.6.0"
-    "@terascope/utils": "npm:~1.6.0"
-  checksum: 10c0/318412e9ffea3687bf718a11e5a46d9424f0acb973fab9fc0bac299435ca5dd727909914783f2fe48a2dc40bda3a4f145d91b92c1f37303853109716272ef573
-  languageName: node
-  linkType: hard
-
-"@terascope/types@npm:~1.3.1":
-  version: 1.3.1
-  resolution: "@terascope/types@npm:1.3.1"
-  dependencies:
-    prom-client: "npm:~15.1.3"
-  checksum: 10c0/c7f06486b12780bfc2463d4f66953f8ca98c1bd893c38c8a2e86a93b8220ea34222d4c968ab3b397be6e89c7b2e6928c5416edba88edac5092f0719fe157f990
+    "@terascope/elasticsearch-api": "npm:~4.7.1"
+    "@terascope/utils": "npm:~1.7.1"
+  checksum: 10c0/aa0b54aa90ae01456f0045ffe0711c323705f052c12cdcd97fa4ff54920809593588d0de509bfd510060f4c4c785178c6fe078adc49259ccef42ed8765c34da2
   languageName: node
   linkType: hard
 
@@ -1354,50 +1328,6 @@ __metadata:
   dependencies:
     prom-client: "npm:~15.1.3"
   checksum: 10c0/a40cea45294a3daf744210739bbb659f51a7b82b2ab7d69e76ba7bcaebd96fdbd737bb54dedeec8c6bf63f95a7da0737f0ef7e7785c1a0721660e9f8693ecb3e
-  languageName: node
-  linkType: hard
-
-"@terascope/utils@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "@terascope/utils@npm:1.6.0"
-  dependencies:
-    "@chainsafe/is-ip": "npm:~2.0.2"
-    "@terascope/types": "npm:~1.3.1"
-    "@turf/bbox": "npm:~7.1.0"
-    "@turf/bbox-polygon": "npm:~7.1.0"
-    "@turf/boolean-contains": "npm:~7.1.0"
-    "@turf/boolean-disjoint": "npm:~7.1.0"
-    "@turf/boolean-equal": "npm:~7.1.0"
-    "@turf/boolean-intersects": "npm:~7.1.0"
-    "@turf/boolean-point-in-polygon": "npm:~7.1.0"
-    "@turf/boolean-within": "npm:~7.1.0"
-    "@turf/circle": "npm:~7.1.0"
-    "@turf/helpers": "npm:~7.1.0"
-    "@turf/invariant": "npm:~7.1.0"
-    "@turf/line-to-polygon": "npm:~7.1.0"
-    "@types/lodash-es": "npm:~4.17.12"
-    "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.2.0"
-    date-fns: "npm:~4.1.0"
-    date-fns-tz: "npm:~3.2.0"
-    datemath-parser: "npm:~1.0.6"
-    debug: "npm:~4.4.0"
-    geo-tz: "npm:~8.1.1"
-    ip-bigint: "npm:~8.2.0"
-    ip-cidr: "npm:~4.0.2"
-    ip6addr: "npm:~0.2.5"
-    ipaddr.js: "npm:~2.2.0"
-    is-cidr: "npm:~5.1.0"
-    is-plain-object: "npm:~5.0.0"
-    js-string-escape: "npm:~1.0.1"
-    kind-of: "npm:~6.0.3"
-    latlon-geohash: "npm:~2.0.0"
-    lodash-es: "npm:~4.17.21"
-    mnemonist: "npm:~0.39.8"
-    p-map: "npm:~7.0.3"
-    shallow-clone: "npm:~3.0.1"
-    validator: "npm:~13.12.0"
-  checksum: 10c0/1f426b20d95beac6425d190ff08206f194719180a37db8cc0d34a0468ba75cd6f0159b5f7e7a7282ba6d4e7e7e7b9902b1cd46318004d6d23256abdaa66cdad9
   languageName: node
   linkType: hard
 
@@ -1974,12 +1904,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~22.10.2":
-  version: 22.10.2
-  resolution: "@types/node@npm:22.10.2"
+"@types/node@npm:~22.10.6":
+  version: 22.10.6
+  resolution: "@types/node@npm:22.10.6"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/2c7b71a040f1ef5320938eca8ebc946e6905caa9bbf3d5665d9b3774a8d15ea9fab1582b849a6d28c7fc80756a62c5666bc66b69f42f4d5dafd1ccb193cdb4ac
+  checksum: 10c0/8b67affc211e5f9c74f7949cda04ca669721e50b83d71b8772a7bed7a4a3c41d663b3a794413f618e763ca6c5da8c234c25ffebcb0737983fc3e7415818ab9a7
   languageName: node
   linkType: hard
 
@@ -4217,17 +4147,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:~9.17.0":
-  version: 9.17.0
-  resolution: "eslint@npm:9.17.0"
+"eslint@npm:~9.18.0":
+  version: 9.18.0
+  resolution: "eslint@npm:9.18.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.0"
-    "@eslint/core": "npm:^0.9.0"
+    "@eslint/core": "npm:^0.10.0"
     "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:9.17.0"
-    "@eslint/plugin-kit": "npm:^0.2.3"
+    "@eslint/js": "npm:9.18.0"
+    "@eslint/plugin-kit": "npm:^0.2.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.1"
@@ -4262,7 +4192,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/9edd8dd782b4ae2eb00a158ed4708194835d4494d75545fa63a51f020ed17f865c49b4ae1914a2ecbc7fdb262bd8059e811aeef9f0bae63dced9d3293be1bbdd
+  checksum: 10c0/7f592ad228b9bd627a24870fdc875bacdab7bf535d4b67316c4cb791e90d0125130a74769f3c407b0c4b7027b3082ef33864a63ee1024552a60a17db60493f15
   languageName: node
   linkType: hard
 
@@ -8879,24 +8809,24 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "standard-assets-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.3"
-    "@terascope/job-components": "npm:~1.8.0"
-    "@terascope/scripts": "npm:~1.7.1"
+    "@terascope/eslint-config": "npm:~1.1.4"
+    "@terascope/job-components": "npm:~1.9.1"
+    "@terascope/scripts": "npm:~1.9.0"
     "@terascope/standard-asset-apis": "npm:~1.0.3"
     "@types/express": "npm:~4.17.19"
     "@types/jest": "npm:~29.5.14"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~22.10.2"
+    "@types/node": "npm:~22.10.6"
     "@types/node-gzip": "npm:~1.1.0"
     "@types/timsort": "npm:~0.3.0"
-    eslint: "npm:~9.17.0"
+    eslint: "npm:~9.18.0"
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
     node-notifier: "npm:~10.0.1"
-    teraslice-test-harness: "npm:~1.2.1"
+    teraslice-test-harness: "npm:~1.3.1"
     ts-jest: "npm:~29.2.5"
     tslib: "npm:~2.8.1"
-    typescript: "npm:~5.2.2"
+    typescript: "npm:~5.7.3"
   languageName: unknown
   linkType: soft
 
@@ -8905,11 +8835,11 @@ __metadata:
   resolution: "standard@workspace:asset"
   dependencies:
     "@faker-js/faker": "npm:~9.3.0"
-    "@terascope/data-mate": "npm:~1.6.0"
-    "@terascope/job-components": "npm:~1.8.0"
+    "@terascope/data-mate": "npm:~1.7.2"
+    "@terascope/job-components": "npm:~1.9.1"
     "@terascope/standard-asset-apis": "npm:~1.0.3"
-    "@terascope/teraslice-state-storage": "npm:~1.6.0"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/teraslice-state-storage": "npm:~1.7.1"
+    "@terascope/utils": "npm:~1.7.1"
     "@types/chance": "npm:~1.1.4"
     "@types/express": "npm:~4.17.19"
     "@types/ms": "npm:^0.7.34"
@@ -8921,7 +8851,7 @@ __metadata:
     randexp: "npm:~0.5.3"
     short-unique-id: "npm:~5.2.0"
     timsort: "npm:~0.3.0"
-    ts-transforms: "npm:~1.6.0"
+    ts-transforms: "npm:~1.7.2"
     tslib: "npm:~2.8.1"
   languageName: unknown
   linkType: soft
@@ -9251,16 +9181,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teraslice-test-harness@npm:~1.2.1":
-  version: 1.2.1
-  resolution: "teraslice-test-harness@npm:1.2.1"
+"teraslice-test-harness@npm:~1.3.1":
+  version: 1.3.1
+  resolution: "teraslice-test-harness@npm:1.3.1"
   dependencies:
     "@terascope/fetch-github-release": "npm:~1.0.0"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.2.0"
   peerDependencies:
-    "@terascope/job-components": ">=1.6.1"
-  checksum: 10c0/b27d9e1a7b4aaba182f88250aa410ee1e71784711c69ff47362c3552d9805bb5b1af6a8304a0bb25ed5fb1578f2493ebb5605d6cfcb1a25b9bb0e42881f159aa
+    "@terascope/job-components": ">=1.9.1"
+  checksum: 10c0/86ee18bf5c2f10a57b1b8d44009b96e593c521a99b74b22e7e11a3e1cf0446e6110a62ca0410cc3019eb742576f2b3cb37fee0d464efc7f19a03c3dbafa285ec
   languageName: node
   linkType: hard
 
@@ -9444,13 +9374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-transforms@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "ts-transforms@npm:1.6.0"
+"ts-transforms@npm:~1.7.2":
+  version: 1.7.2
+  resolution: "ts-transforms@npm:1.7.2"
   dependencies:
-    "@terascope/data-mate": "npm:~1.6.0"
-    "@terascope/types": "npm:~1.3.1"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/data-mate": "npm:~1.7.2"
+    "@terascope/types": "npm:~1.4.1"
+    "@terascope/utils": "npm:~1.7.1"
     awesome-phonenumber: "npm:~7.2.0"
     graphlib: "npm:~2.1.8"
     jexl: "npm:~2.3.0"
@@ -9459,9 +9389,9 @@ __metadata:
     validator: "npm:~13.12.0"
     yargs: "npm:~17.7.2"
   bin:
-    ts-match: bin/ts-transform.js
-    ts-transform: bin/ts-transform.js
-  checksum: 10c0/0a251cb3ffd2f829e505c7bd725b20f08726a79cca25ee10819008e9c17db9c48e73dca16af865c8b1285ec69ff5325fefd354ee9d3a93b71092c750c9a43ec4
+    ts-match: ./bin/ts-transform.js
+    ts-transform: ./bin/ts-transform.js
+  checksum: 10c0/7f40d5b60c62072479312d0b0580c4070b9f591c168067442344930037a4c8a60b008bca298f4c50b6321b259c6a37cac8e5b9d8053000e9509d74b5ac724d6e
   languageName: node
   linkType: hard
 
@@ -9640,23 +9570,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.2.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:~5.7.2, typescript@npm:~5.7.3":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/91ae3e6193d0ddb8656d4c418a033f0f75dec5e077ebbc2bd6d76439b93f35683936ee1bdc0e9cf94ec76863aa49f27159b5788219b50e1cd0cd6d110aa34b07
+  checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.2.2#optional!builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+"typescript@patch:typescript@npm%3A~5.7.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/062c1cee1990e6b9419ce8a55162b8dc917eb87f807e4de0327dbc1c2fa4e5f61bc0dd4e034d38ff541d1ed0479b53bcee8e4de3a4075c51a1724eb6216cb6f5
+  checksum: 10c0/6fd7e0ed3bf23a81246878c613423730c40e8bdbfec4c6e4d7bf1b847cbb39076e56ad5f50aa9d7ebd89877999abaee216002d3f2818885e41c907caaa192cc4
   languageName: node
   linkType: hard
 
@@ -10046,15 +9976,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.6.0":
-  version: 1.6.0
-  resolution: "xlucene-parser@npm:1.6.0"
+"xlucene-parser@npm:~1.7.2":
+  version: 1.7.2
+  resolution: "xlucene-parser@npm:1.7.2"
   dependencies:
-    "@terascope/types": "npm:~1.3.1"
-    "@terascope/utils": "npm:~1.6.0"
+    "@terascope/types": "npm:~1.4.1"
+    "@terascope/utils": "npm:~1.7.1"
     peggy: "npm:~4.2.0"
     ts-pegjs: "npm:~4.2.1"
-  checksum: 10c0/c6bc42d28a5a41a33aee650476b63e2a99fdb8b82bdf52d1f9fc0e491a9ad6d2131133c0a92204a3f088197db9b0cad06d592022c7e1b955266e67c8d2337c03
+  checksum: 10c0/ff6ebdb50a46caf9a0237031724be14e2bacdc427054bf877f519dc9bade07785060c7d33aaf15dd6586bd1d9d7fb383e64648e9cc692835ca09af77cb34369f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes the following updates:
- standard asset
  - dependencies
    - @terascope/data-mate from 1.6.0 to 1.7.2
    - @terascope/job-components from 1.8.0 to 1.9.1
    - @terascope/teraslice-state-storage from 1.6.0 to 1.7.1
    - @terascope/utils from 1.6.0 to 1.7.1
    - ts-transforms from 1.6.0 to 1.7.2
- standard-asset-apis
  - dependencies
    - @terascope/utils from 1.6.0 to 1.7.1
  - devDependencies
    - @types/node from 22.10.2 to 22.10.5
- workspace
  - devDependencies
    - @terascope/eslint-config from 1.1.3 to 1.1.4
    - @terascope/job-components from 1.8.0 to 1.9.1
    - @terascope-scripts from 1.7.1 to 1.9.0
    - @types/node from 22.10.2 to 22.10.5
    - eslint from 9.17.0 to 9.18.0
    - teraslice-test-harness from 1.2.1 to 1.3.1
    - typescript from 5.2.2 to 5.7.3