### PR TITLE
fix bug in sample_random when probability_to_keep is 0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/src/sample_random/processor.ts
+++ b/asset/src/sample_random/processor.ts
@@ -6,7 +6,7 @@ export default class SampleRandom extends BatchProcessor<SampleRandomConfig> {
         const outData: DataEntity[] = [];
 
         for (const doc of dataArray) {
-            if (random(0, 99) <= this.opConfig.probability_to_keep) {
+            if (random(1, 100) <= this.opConfig.probability_to_keep) {
                 outData.push(doc);
             }
         }

--- a/docs/operations/sample_random.md
+++ b/docs/operations/sample_random.md
@@ -1,6 +1,6 @@
 # sample_random
 
-given an array of JSON documents will return an array containing a subset of those input documents.  It iterates through the array and generates a random number between 0 and 100 for each record, and if the number <= probability it is kept. Must be between 0 and 100, with 100 keeping all records and 0 rejecting all records.
+given an array of JSON documents will return an array containing a subset of those input documents.  It iterates through the array and generates a random number between 1 and 100 for each record, and if the number <= probability it is kept. Must be between 0 and 100, with 100 keeping all records and 0 rejecting all records.
 
 ## Usage
 
@@ -29,6 +29,7 @@ Example of a job using the `sample_random` processor
 }
 
 ```
+
 Example of the data and the expected results
 
 ```javascript
@@ -52,4 +53,4 @@ results === [
 | Configuration | Description                                                   | Type   | Notes                        |
 | ------------- | ------------------------------------------------------------- | ------ | ---------------------------- |
 | _op           | Name of operation, it must reflect the exact name of the file | String | required |
-| probability_to_keep   | The probability of the record being kept. It iterates through the array and generates a random number between 0 and 100, and if the number <= probability it is kept. Must be between 0 and 100, with 100 keeping all records and 0 rejecting all records | required, defaults to 100 |
+| probability_to_keep   | The probability of the record being kept. It iterates through the array and generates a random number between 1 and 100, and if the number <= probability it is kept. Must be between 0 and 100, with 100 keeping all records and 0 rejecting all records | Number, defaults to 100 | required |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "type": "module",

--- a/test/sample_random/processor-spec.ts
+++ b/test/sample_random/processor-spec.ts
@@ -77,6 +77,14 @@ describe('sample_random', () => {
         expect(results.length).toBeLessThan(5400);
         expect(results.length).toBeGreaterThan(4600);
     });
+
+    it('with large datasets and 0%', async () => {
+        const data = makeData(10000);
+        harness = await makeTest({ probability_to_keep: 0 });
+        const results = await harness.runSlice(data);
+
+        expect(results.length).toEqual(0);
+    });
 });
 
 interface FakeData {


### PR DESCRIPTION
This PR makes the following changes:
- Fixes a bug in the `sample_random` processor when `probability_to_keep` is set to 0%. If the random number generator returns 0 then a record would be returned ( 0 <= 0 is true ). Setting the `random()` function's minimum value to 1 ensures that no records will ever be returned ( 1 <= 0 is false).
- Update docs
- Add test with large dataset and `probability_to_keep` set to 0%
- bump standard asset from v1.3.1 to v1.3.2

ref: #988 