### PR TITLE
bundled dependency updates

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -21,12 +21,12 @@
         "test": "yarn --cwd ../ test"
     },
     "dependencies": {
-        "@faker-js/faker": "~9.5.0",
-        "@terascope/data-mate": "~1.7.6",
-        "@terascope/job-components": "~1.9.6",
+        "@faker-js/faker": "~9.5.1",
+        "@terascope/data-mate": "~1.7.7",
+        "@terascope/job-components": "~1.9.7",
         "@terascope/standard-asset-apis": "~1.0.3",
-        "@terascope/teraslice-state-storage": "~1.8.3",
-        "@terascope/utils": "~1.7.5",
+        "@terascope/teraslice-state-storage": "~1.8.4",
+        "@terascope/utils": "~1.7.6",
         "@types/chance": "~1.1.6",
         "@types/express": "~4.17.21",
         "chance": "~1.1.12",
@@ -37,7 +37,7 @@
         "randexp": "~0.5.3",
         "short-unique-id": "~5.2.0",
         "timsort": "~0.3.0",
-        "ts-transforms": "~1.7.6",
+        "ts-transforms": "~1.7.7",
         "tslib": "~2.8.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.7",
-        "@terascope/job-components": "~1.9.6",
-        "@terascope/scripts": "~1.10.4",
+        "@terascope/eslint-config": "~1.1.8",
+        "@terascope/job-components": "~1.9.7",
+        "@terascope/scripts": "~1.11.0",
         "@terascope/standard-asset-apis": "~1.0.3",
         "@types/express": "~4.17.21",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~22.13.5",
+        "@types/node": "~22.13.8",
         "@types/node-gzip": "~1.1.3",
         "@types/semver": "~7.5.8",
         "@types/timsort": "~0.3.3",
@@ -50,7 +50,7 @@
         "teraslice-test-harness": "~1.3.2",
         "ts-jest": "~29.2.6",
         "tslib": "~2.8.1",
-        "typescript": "~5.7.3"
+        "typescript": "~5.8.2"
     },
     "packageManager": "yarn@4.6.0",
     "engines": {

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,17 +22,17 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "~3.1.0",
-        "@terascope/utils": "~1.7.5"
+        "@terascope/utils": "~1.7.6"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.10.4",
+        "@terascope/scripts": "~1.11.0",
         "@types/jest": "~29.5.14",
-        "@types/node": "~22.13.5",
+        "@types/node": "~22.13.8",
         "jest": "~29.7.0",
         "jest-extended": "~4.0.2",
         "jest-fixtures": "~0.6.0",
         "ts-jest": "~29.2.6",
-        "typescript": "~5.7.3"
+        "typescript": "~5.8.2"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,26 +449,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:~1.2.6":
-  version: 1.2.6
-  resolution: "@eslint/compat@npm:1.2.6"
+"@eslint/compat@npm:~1.2.7":
+  version: 1.2.7
+  resolution: "@eslint/compat@npm:1.2.7"
   peerDependencies:
     eslint: ^9.10.0
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10c0/e767b62f1e43a1b4e3f9f1ac64546f8bcdf4f3fb84c504d8f1b0ea31a71f1607bcd11288c86c77b8ddd3d0bba9a9513d7203d4e6d15b1b3a1cff7718dea61b40
-  languageName: node
-  linkType: hard
-
-"@eslint/config-array@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "@eslint/config-array@npm:0.19.0"
-  dependencies:
-    "@eslint/object-schema": "npm:^2.1.4"
-    debug: "npm:^4.3.1"
-    minimatch: "npm:^3.1.2"
-  checksum: 10c0/def23c6c67a8f98dc88f1b87e17a5668e5028f5ab9459661aabfe08e08f2acd557474bbaf9ba227be0921ae4db232c62773dbb7739815f8415678eb8f592dbf5
+  checksum: 10c0/df89a0396750748c3748eb5fc582bd6cb89be6599d88ed1c5cc60ae0d13f77d4bf5fb30fabdb6c9ce16dda35745ef2e6417fa82548cde7d2b3fa5a896da02c8e
   languageName: node
   linkType: hard
 
@@ -483,47 +472,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "@eslint/core@npm:0.10.0"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/074018075079b3ed1f14fab9d116f11a8824cdfae3e822badf7ad546962fafe717a31e61459bad8cc59cf7070dc413ea9064ddb75c114f05b05921029cde0a64
-  languageName: node
-  linkType: hard
-
-"@eslint/core@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@eslint/core@npm:0.11.0"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/1e0671d035c908175f445864a7864cf6c6a8b67a5dfba8c47b2ac91e2d3ed36e8c1f2fd81d98a73264f8677055559699d4adb0f97d86588e616fc0dc9a4b86c9
-  languageName: node
-  linkType: hard
-
 "@eslint/core@npm:^0.12.0":
   version: 0.12.0
   resolution: "@eslint/core@npm:0.12.0"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
   checksum: 10c0/d032af81195bb28dd800c2b9617548c6c2a09b9490da3c5537fd2a1201501666d06492278bb92cfccac1f7ac249e58601dd87f813ec0d6a423ef0880434fa0c3
-  languageName: node
-  linkType: hard
-
-"@eslint/eslintrc@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@eslint/eslintrc@npm:3.2.0"
-  dependencies:
-    ajv: "npm:^6.12.4"
-    debug: "npm:^4.3.2"
-    espree: "npm:^10.0.1"
-    globals: "npm:^14.0.0"
-    ignore: "npm:^5.2.0"
-    import-fresh: "npm:^3.2.1"
-    js-yaml: "npm:^4.1.0"
-    minimatch: "npm:^3.1.2"
-    strip-json-comments: "npm:^3.1.1"
-  checksum: 10c0/43867a07ff9884d895d9855edba41acf325ef7664a8df41d957135a81a477ff4df4196f5f74dc3382627e5cc8b7ad6b815c2cea1b58f04a75aced7c43414ab8b
   languageName: node
   linkType: hard
 
@@ -544,24 +498,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.20.0, @eslint/js@npm:~9.20.0":
-  version: 9.20.0
-  resolution: "@eslint/js@npm:9.20.0"
-  checksum: 10c0/10e7b5b9e628b5192e8fc6b0ecd27cf48322947e83e999ff60f9f9e44ac8d499138bcb9383cbfa6e51e780d53b4e76ccc2d1753b108b7173b8404fd484d37328
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.21.0":
+"@eslint/js@npm:9.21.0, @eslint/js@npm:~9.21.0":
   version: 9.21.0
   resolution: "@eslint/js@npm:9.21.0"
   checksum: 10c0/86c24a2668808995037e3f40c758335df2ae277c553ac0cf84381a1a8698f3099d8a22dd9c388947e6b7f93fcc1142f62406072faaa2b83c43ca79993fc01bb3
-  languageName: node
-  linkType: hard
-
-"@eslint/object-schema@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@eslint/object-schema@npm:2.1.4"
-  checksum: 10c0/e9885532ea70e483fb007bf1275968b05bb15ebaa506d98560c41a41220d33d342e19023d5f2939fed6eb59676c1bda5c847c284b4b55fce521d282004da4dda
   languageName: node
   linkType: hard
 
@@ -569,16 +509,6 @@ __metadata:
   version: 2.1.6
   resolution: "@eslint/object-schema@npm:2.1.6"
   checksum: 10c0/b8cdb7edea5bc5f6a96173f8d768d3554a628327af536da2fc6967a93b040f2557114d98dbcdbf389d5a7b290985ad6a9ce5babc547f36fc1fde42e674d11a56
-  languageName: node
-  linkType: hard
-
-"@eslint/plugin-kit@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "@eslint/plugin-kit@npm:0.2.5"
-  dependencies:
-    "@eslint/core": "npm:^0.10.0"
-    levn: "npm:^0.4.1"
-  checksum: 10c0/ba9832b8409af618cf61791805fe201dd62f3c82c783adfcec0f5cd391e68b40beaecb47b9a3209e926dbcab65135f410cae405b69a559197795793399f61176
   languageName: node
   linkType: hard
 
@@ -592,10 +522,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:~9.5.0":
-  version: 9.5.0
-  resolution: "@faker-js/faker@npm:9.5.0"
-  checksum: 10c0/97c983e0752e36bd2322fe0bda273e41093ae868452811b3146d33412147a03b343a6720a2e388d4c4a06c5c6ce89cad9e6c2c363008ef061a26c4fce067c22d
+"@faker-js/faker@npm:~9.5.1":
+  version: 9.5.1
+  resolution: "@faker-js/faker@npm:9.5.1"
+  checksum: 10c0/b1b89a511162e43426b12f659f7a0d89a3cd1643ecda0d695f20eef65e21e466189ee89d07333592dedc9cee4cafd0dcb0f0b054a2e473b25f4f5fd945293a02
   languageName: node
   linkType: hard
 
@@ -638,13 +568,6 @@ __metadata:
   version: 0.3.1
   resolution: "@humanwhocodes/retry@npm:0.3.1"
   checksum: 10c0/f0da1282dfb45e8120480b9e2e275e2ac9bbe1cf016d046fdad8e27cc1285c45bb9e711681237944445157b430093412b4446c1ab3fc4bb037861b5904101d3b
-  languageName: node
-  linkType: hard
-
-"@humanwhocodes/retry@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@humanwhocodes/retry@npm:0.4.1"
-  checksum: 10c0/be7bb6841c4c01d0b767d9bb1ec1c9359ee61421ce8ba66c249d035c5acdfd080f32d55a5c9e859cdd7868788b8935774f65b2caf24ec0b7bd7bf333791f063b
   languageName: node
   linkType: hard
 
@@ -1203,18 +1126,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~3.1.0":
-  version: 3.1.0
-  resolution: "@stylistic/eslint-plugin@npm:3.1.0"
+"@stylistic/eslint-plugin@npm:~4.0.1":
+  version: 4.0.1
+  resolution: "@stylistic/eslint-plugin@npm:4.0.1"
   dependencies:
-    "@typescript-eslint/utils": "npm:^8.13.0"
+    "@typescript-eslint/utils": "npm:^8.23.0"
     eslint-visitor-keys: "npm:^4.2.0"
     espree: "npm:^10.3.0"
     estraverse: "npm:^5.3.0"
     picomatch: "npm:^4.0.2"
   peerDependencies:
-    eslint: ">=8.40.0"
-  checksum: 10c0/e593d78103a89e0555c119625c0ba8c80c8d2c7add0e85215f6be9929002207067df53714785c2c75b8b9e6df774d25c7dead211aed89a57cb45b5cec902a19e
+    eslint: ">=9.0.0"
+  checksum: 10c0/a1a875eaa43a494ce34d490f93f1e61e1b1dfb4d6fafaef54f1ad6db768a8758714e1e826946bd0e8d403af13d0d63820a50f089383f868199a44cd57bddc137
   languageName: node
   linkType: hard
 
@@ -1227,13 +1150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.6":
-  version: 1.7.6
-  resolution: "@terascope/data-mate@npm:1.7.6"
+"@terascope/data-mate@npm:~1.7.7":
+  version: 1.7.7
+  resolution: "@terascope/data-mate@npm:1.7.7"
   dependencies:
-    "@terascope/data-types": "npm:~1.7.5"
+    "@terascope/data-types": "npm:~1.7.6"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     "@types/validator": "npm:~13.12.2"
     awesome-phonenumber: "npm:~7.3.0"
     date-fns: "npm:~4.1.0"
@@ -1242,52 +1165,51 @@ __metadata:
     ipaddr.js: "npm:~2.2.0"
     is-cidr: "npm:~5.1.1"
     jexl: "npm:~2.3.0"
-    mnemonist: "npm:~0.40.2"
-    uuid: "npm:~11.0.5"
+    mnemonist: "npm:~0.40.3"
+    uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.6"
-  checksum: 10c0/ec416525b8c9dacec2a03adcd9e58e924acd79e5673ca7e31e383acb89f52c114724dbca8812d087711a40e0cb4ff970dcfad16ce9cf9c819f2934cc743de398
+    xlucene-parser: "npm:~1.7.7"
+  checksum: 10c0/8d4e9291f0403fb374825791be31c49c196b605a92ef180ec1dbffa6050fc9806f6c58fe68661a698c185fbf1a346f39d0c90e18f78dd6c5abae31508645f7a9
   languageName: node
   linkType: hard
 
-"@terascope/data-types@npm:~1.7.5":
-  version: 1.7.5
-  resolution: "@terascope/data-types@npm:1.7.5"
+"@terascope/data-types@npm:~1.7.6":
+  version: 1.7.6
+  resolution: "@terascope/data-types@npm:1.7.6"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
   bin:
     data-types: ./bin/data-types.js
-  checksum: 10c0/759561def602d6112afadc6890cd9f9fb78119d5bb814b3afc4823d3b2be6917929ad2b1b68d3e911c9f8c169f0ce81ba3b6c87ce6ec8473fdf3abb0b7797727
+  checksum: 10c0/e3df1a54a14156e3b3ed8e518e4d6919c284347198cb410215f3347ee64be92fd2aa0ef231e373008f6d54aa95eedad4210c3021376c760f8d9cfe3a7ea35831
   languageName: node
   linkType: hard
 
-"@terascope/elasticsearch-api@npm:~4.8.3":
-  version: 4.8.3
-  resolution: "@terascope/elasticsearch-api@npm:4.8.3"
+"@terascope/elasticsearch-api@npm:~4.8.4":
+  version: 4.8.4
+  resolution: "@terascope/elasticsearch-api@npm:4.8.4"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     bluebird: "npm:~3.7.2"
     setimmediate: "npm:~1.0.5"
-  checksum: 10c0/89140a544be019c9b69b44de8cc027cdb48f30a7fbb3d22efee9fb41b3aa7820ecbc52c2961a4eeed1a0d91c86f7d037806836204a97c19441c338e4c608a733
+  checksum: 10c0/7fb8bd63d5e10adbf821ecbb331922cd196b0cb6fd8e7dce78cb29ee2a632b6624a82e48cdd68cf42cc5d1b51fddf09ac786d662cf0a7488fed61cafa71182ed
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.7":
-  version: 1.1.7
-  resolution: "@terascope/eslint-config@npm:1.1.7"
+"@terascope/eslint-config@npm:~1.1.8":
+  version: 1.1.8
+  resolution: "@terascope/eslint-config@npm:1.1.8"
   dependencies:
-    "@eslint/compat": "npm:~1.2.6"
-    "@eslint/js": "npm:~9.20.0"
-    "@stylistic/eslint-plugin": "npm:~3.1.0"
-    "@types/eslint__js": "npm:~8.42.3"
+    "@eslint/compat": "npm:~1.2.7"
+    "@eslint/js": "npm:~9.21.0"
+    "@stylistic/eslint-plugin": "npm:~4.0.1"
     "@typescript-eslint/eslint-plugin": "npm:~8.24.1"
     "@typescript-eslint/parser": "npm:~8.24.1"
-    eslint: "npm:~9.20.1"
+    eslint: "npm:~9.21.0"
     eslint-plugin-import: "npm:~2.31.0"
     eslint-plugin-jest: "npm:~28.11.0"
     eslint-plugin-jest-dom: "npm:~5.5.0"
@@ -1295,10 +1217,10 @@ __metadata:
     eslint-plugin-react: "npm:~7.37.4"
     eslint-plugin-react-hooks: "npm:~5.1.0"
     eslint-plugin-testing-library: "npm:~7.1.1"
-    globals: "npm:~15.15.0"
+    globals: "npm:~16.0.0"
     typescript: "npm:~5.7.3"
     typescript-eslint: "npm:~8.24.1"
-  checksum: 10c0/b5e881af6e0d701eb936c7f99f97a30640f521325301d52637b1f30a423f1a94fba22f422bdd16d7c38a59ba19011084aa414605d30adf9e293dcf0522260453
+  checksum: 10c0/57a90f72442fed204929db946a9f9b1c7713ebbdf00ab50876afe81287ca21d8420b20ae8aaff36600755c4acc7cf1f24c9fa1b8fd79583006d25fe83866002d
   languageName: node
   linkType: hard
 
@@ -1317,12 +1239,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.9.6":
-  version: 1.9.6
-  resolution: "@terascope/job-components@npm:1.9.6"
+"@terascope/job-components@npm:~1.9.7":
+  version: 1.9.7
+  resolution: "@terascope/job-components@npm:1.9.7"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
@@ -1330,17 +1252,17 @@ __metadata:
     import-meta-resolve: "npm:~4.1.0"
     prom-client: "npm:~15.1.3"
     semver: "npm:~7.7.1"
-    uuid: "npm:~11.0.5"
-  checksum: 10c0/04e4604a6e94beb223a2c1731d67e1e3ff6336cf99ad19c533ef3f062928b5c1f2a4390b87724c67fc7af2beddd58d1b36e8ccc8cd2b571b94d3b93bc9fe508f
+    uuid: "npm:~11.1.0"
+  checksum: 10c0/77415109760c0b40fc72540c3eb9a0959c33ba16cf15acfd8f1adb2a6dfb13b4ab226fc5151ac460eaa96f7cc0baa045bb5c31887a6837620476f04ecea825f6
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.10.4":
-  version: 1.10.4
-  resolution: "@terascope/scripts@npm:1.10.4"
+"@terascope/scripts@npm:~1.11.0":
+  version: 1.11.0
+  resolution: "@terascope/scripts@npm:1.11.0"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     codecov: "npm:~3.8.3"
     execa: "npm:~9.5.2"
     fs-extra: "npm:~11.3.0"
@@ -1350,7 +1272,7 @@ __metadata:
     js-yaml: "npm:~4.1.0"
     kafkajs: "npm:~2.2.4"
     micromatch: "npm:~4.0.8"
-    mnemonist: "npm:~0.40.2"
+    mnemonist: "npm:~0.40.3"
     ms: "npm:~2.1.3"
     package-json: "npm:~10.0.1"
     package-up: "npm:~5.0.0"
@@ -1358,7 +1280,7 @@ __metadata:
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~2.14.0"
     toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.27.7"
+    typedoc: "npm:~0.27.8"
     typedoc-plugin-markdown: "npm:~4.4.2"
     yargs: "npm:~17.7.2"
   peerDependencies:
@@ -1368,7 +1290,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/873845c6d235cf1f0899511bacc7bb9a33be34da643e3eb3237d3b8f849b0faf36438779a98cf318f3ca7f4aa3e5ae9274771faca14673791c61706a6922c80a
+  checksum: 10c0/69a554db5a690723471e42cc5d85267144f1b6ee378d21b9e4db85704309fce7445ac9594f3e9c150099c3d4a16fb4251f8dc3967d2432f9d4f86ba5acd31911
   languageName: node
   linkType: hard
 
@@ -1377,25 +1299,25 @@ __metadata:
   resolution: "@terascope/standard-asset-apis@workspace:packages/standard-asset-apis"
   dependencies:
     "@sindresorhus/fnv1a": "npm:~3.1.0"
-    "@terascope/scripts": "npm:~1.10.4"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/scripts": "npm:~1.11.0"
+    "@terascope/utils": "npm:~1.7.6"
     "@types/jest": "npm:~29.5.14"
-    "@types/node": "npm:~22.13.5"
+    "@types/node": "npm:~22.13.8"
     jest: "npm:~29.7.0"
     jest-extended: "npm:~4.0.2"
     jest-fixtures: "npm:~0.6.0"
     ts-jest: "npm:~29.2.6"
-    typescript: "npm:~5.7.3"
+    typescript: "npm:~5.8.2"
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-state-storage@npm:~1.8.3":
-  version: 1.8.3
-  resolution: "@terascope/teraslice-state-storage@npm:1.8.3"
+"@terascope/teraslice-state-storage@npm:~1.8.4":
+  version: 1.8.4
+  resolution: "@terascope/teraslice-state-storage@npm:1.8.4"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.8.3"
-    "@terascope/utils": "npm:~1.7.5"
-  checksum: 10c0/3207a9471d4935d04141b237cd9c7a9f7674428469c7d36344f5736ffde0fb27a5c706ead760cc5cff1cd5b1f3bb14b357f9d93a261689e074f737ecab04fdae
+    "@terascope/elasticsearch-api": "npm:~4.8.4"
+    "@terascope/utils": "npm:~1.7.6"
+  checksum: 10c0/dee9a44f6adbfa9e6d69e66d9209c6a81565be421f0b94a9e4b76c3c76355318ac58e6085993e6f1c924ecffea0be9266e5d61c8c29e046c79bc61cb2311105a
   languageName: node
   linkType: hard
 
@@ -1408,9 +1330,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.7.5":
-  version: 1.7.5
-  resolution: "@terascope/utils@npm:1.7.5"
+"@terascope/utils@npm:~1.7.6":
+  version: 1.7.6
+  resolution: "@terascope/utils@npm:1.7.6"
   dependencies:
     "@chainsafe/is-ip": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.1"
@@ -1444,11 +1366,11 @@ __metadata:
     kind-of: "npm:~6.0.3"
     latlon-geohash: "npm:~2.0.0"
     lodash-es: "npm:~4.17.21"
-    mnemonist: "npm:~0.40.2"
+    mnemonist: "npm:~0.40.3"
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
-  checksum: 10c0/8d128eca99023eedad29e964a0c1b39d18e499d7aa21cc6bd1bb7b9c96f98cb39a628bcb7dfbb6379880895864e09cc83250449bee72c1cf45b445d903d9653e
+  checksum: 10c0/b5c2d558e235f39936f9956bf7332790b2b95bdb1783c3950fe71d5a1d8edc8245546d1922ab5e32219a23fd34ce8cd3445752cde4f901a7b1a09a1b1685ece1
   languageName: node
   linkType: hard
 
@@ -1808,26 +1730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:*":
-  version: 9.6.1
-  resolution: "@types/eslint@npm:9.6.1"
-  dependencies:
-    "@types/estree": "npm:*"
-    "@types/json-schema": "npm:*"
-  checksum: 10c0/69ba24fee600d1e4c5abe0df086c1a4d798abf13792d8cfab912d76817fe1a894359a1518557d21237fbaf6eda93c5ab9309143dee4c59ef54336d1b3570420e
-  languageName: node
-  linkType: hard
-
-"@types/eslint__js@npm:~8.42.3":
-  version: 8.42.3
-  resolution: "@types/eslint__js@npm:8.42.3"
-  dependencies:
-    "@types/eslint": "npm:*"
-  checksum: 10c0/ccc5180b92155929a089ffb03ed62625216dcd5e46dd3197c6f82370ce8b52c7cb9df66c06b0a3017995409e023bc9eafe5a3f009e391960eacefaa1b62d9a56
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:*, @types/estree@npm:^1.0.6":
+"@types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
@@ -1942,7 +1845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15":
+"@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -2022,12 +1925,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~22.13.5":
-  version: 22.13.5
-  resolution: "@types/node@npm:22.13.5"
+"@types/node@npm:~22.13.8":
+  version: 22.13.8
+  resolution: "@types/node@npm:22.13.8"
   dependencies:
     undici-types: "npm:~6.20.0"
-  checksum: 10c0/a2e7ed7bb0690e439004779baedeb05159c5cc41ef6d81c7a6ebea5303fde4033669e1c0e41ff7453b45fd2fea8dbd55fddfcd052950c7fcae3167c970bca725
+  checksum: 10c0/bfc92b734a9dce6ac5daee0a52feccdf5dcb3804d895e4bc5384e2f4644612b8801725cd03c8c3c0888fb5eeb16b875877ac44b77641e0196dc1a837b1c2a366
   languageName: node
   linkType: hard
 
@@ -2183,6 +2086,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.25.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+  checksum: 10c0/0a53a07873bdb569be38053ec006009cc8ba6b12c538b6df0935afd18e431cb17da1eb15b0c9cd267ac211c47aaa44fbc8d7ff3b7b44ff711621ff305fa3b355
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.4.0":
   version: 8.4.0
   resolution: "@typescript-eslint/scope-manager@npm:8.4.0"
@@ -2219,6 +2132,13 @@ __metadata:
   version: 8.24.1
   resolution: "@typescript-eslint/types@npm:8.24.1"
   checksum: 10c0/ebb40ce16c746ef236dbcc25cb2e6950753ca6fb34d04ed7d477016370de1fdaf7402ed4569673c6ff14bf60af7124ff45c6ddd9328d2f8c94dc04178368e2a3
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/types@npm:8.25.0"
+  checksum: 10c0/b39addbee4be4d66e3089c2d01f9f1d69cedc13bff20e4fa9ed0ca5a0e7591d7c6e41ab3763c8c35404f971bc0fbf9f7867dbc2832740e5b63ee0049d60289f5
   languageName: node
   linkType: hard
 
@@ -2263,6 +2183,24 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <5.8.0"
   checksum: 10c0/8eeeae6e8de1cd83f2eddd52293e9c31a655e0974cc2d410f00ba2b6fd6bb9aec1c346192d5784d64d0d1b15a55e56e35550788c04dda87e0f1a99b21a3eb709
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.25.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 10c0/fc9de1c4f6ab81fb80b632dedef84d1ecf4c0abdc5f5246698deb6d86d5c6b5d582ef8a44fdef445bf7fbfa6658db516fe875c9d7c984bf4802e3a508b061856
   languageName: node
   linkType: hard
 
@@ -2314,7 +2252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^8.13.0, @typescript-eslint/utils@npm:^8.15.0":
+"@typescript-eslint/utils@npm:^8.15.0":
   version: 8.17.0
   resolution: "@typescript-eslint/utils@npm:8.17.0"
   dependencies:
@@ -2328,6 +2266,21 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/a9785ae5f7e7b51d521dc3f48b15093948e4fcd03352c0b60f39bae366cbc935947d215f91e2ae3182d52fa6affb5ccbb50feff487bd1209011f3e0da02cdf07
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^8.23.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/utils@npm:8.25.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.25.0"
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/typescript-estree": "npm:8.25.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 10c0/cd15c4919f02899fd3975049a0a051a1455332a108c085a3e90ae9872e2cddac7f20a9a2c616f1366fca84274649e836ad6a437c9c5ead0bdabf5a123d12403f
   languageName: node
   linkType: hard
 
@@ -2348,6 +2301,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.24.1"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/ba09412fb4b1605aa73c890909c9a8dba2aa72e00ccd7d69baad17c564eedd77f489a06b1686985c7f0c49724787b82d76dcf4c146c4de44ef2c8776a9b6ad2b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.25.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.25.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.25.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: 10c0/7eb84c5899a25b1eb89d3c3f4be3ff18171f934669c57e2530b6dfa5fdd6eaae60629f3c89d06f4c8075fd1c701de76c0b9194e2922895c661ab6091e48f7db9
   languageName: node
   linkType: hard
 
@@ -4393,55 +4356,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:~9.20.1":
-  version: 9.20.1
-  resolution: "eslint@npm:9.20.1"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.19.0"
-    "@eslint/core": "npm:^0.11.0"
-    "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:9.20.0"
-    "@eslint/plugin-kit": "npm:^0.2.5"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.1"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.2.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/056789dd5a00897730376f8c0a191e22840e97b7276916068ec096341cb2ec3a918c8bd474bf94ccd7b457ad9fbc16e5c521a993c7cc6ebcf241933e2fd378b0
-  languageName: node
-  linkType: hard
-
 "eslint@npm:~9.21.0":
   version: 9.21.0
   resolution: "eslint@npm:9.21.0"
@@ -5333,10 +5247,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:~15.15.0":
-  version: 15.15.0
-  resolution: "globals@npm:15.15.0"
-  checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
+"globals@npm:~16.0.0":
+  version: 16.0.0
+  resolution: "globals@npm:16.0.0"
+  checksum: 10c0/8906d5f01838df64a81d6c2a7b7214312e2216cf65c5ed1546dc9a7d0febddf55ffa906cf04efd5b01eec2534d6f14859a89535d1a68241832810e41ef3fd5bb
   languageName: node
   linkType: hard
 
@@ -7640,7 +7554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mnemonist@npm:~0.40.2":
+"mnemonist@npm:~0.40.3":
   version: 0.40.3
   resolution: "mnemonist@npm:0.40.3"
   dependencies:
@@ -7686,7 +7600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:~5.1.0":
+"nanoid@npm:~5.1.2":
   version: 5.1.2
   resolution: "nanoid@npm:5.1.2"
   bin:
@@ -9446,15 +9360,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "standard-assets-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.7"
-    "@terascope/job-components": "npm:~1.9.6"
-    "@terascope/scripts": "npm:~1.10.4"
+    "@terascope/eslint-config": "npm:~1.1.8"
+    "@terascope/job-components": "npm:~1.9.7"
+    "@terascope/scripts": "npm:~1.11.0"
     "@terascope/standard-asset-apis": "npm:~1.0.3"
     "@types/express": "npm:~4.17.21"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~22.13.5"
+    "@types/node": "npm:~22.13.8"
     "@types/node-gzip": "npm:~1.1.3"
     "@types/semver": "npm:~7.5.8"
     "@types/timsort": "npm:~0.3.3"
@@ -9467,7 +9381,7 @@ __metadata:
     teraslice-test-harness: "npm:~1.3.2"
     ts-jest: "npm:~29.2.6"
     tslib: "npm:~2.8.1"
-    typescript: "npm:~5.7.3"
+    typescript: "npm:~5.8.2"
   languageName: unknown
   linkType: soft
 
@@ -9475,12 +9389,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "standard@workspace:asset"
   dependencies:
-    "@faker-js/faker": "npm:~9.5.0"
-    "@terascope/data-mate": "npm:~1.7.6"
-    "@terascope/job-components": "npm:~1.9.6"
+    "@faker-js/faker": "npm:~9.5.1"
+    "@terascope/data-mate": "npm:~1.7.7"
+    "@terascope/job-components": "npm:~1.9.7"
     "@terascope/standard-asset-apis": "npm:~1.0.3"
-    "@terascope/teraslice-state-storage": "npm:~1.8.3"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/teraslice-state-storage": "npm:~1.8.4"
+    "@terascope/utils": "npm:~1.7.6"
     "@types/chance": "npm:~1.1.6"
     "@types/express": "npm:~4.17.21"
     "@types/ms": "npm:^0.7.34"
@@ -9492,7 +9406,7 @@ __metadata:
     randexp: "npm:~0.5.3"
     short-unique-id: "npm:~5.2.0"
     timsort: "npm:~0.3.0"
-    ts-transforms: "npm:~1.7.6"
+    ts-transforms: "npm:~1.7.7"
     tslib: "npm:~2.8.1"
   languageName: unknown
   linkType: soft
@@ -10052,24 +9966,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-transforms@npm:~1.7.6":
-  version: 1.7.6
-  resolution: "ts-transforms@npm:1.7.6"
+"ts-transforms@npm:~1.7.7":
+  version: 1.7.7
+  resolution: "ts-transforms@npm:1.7.7"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.6"
+    "@terascope/data-mate": "npm:~1.7.7"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     awesome-phonenumber: "npm:~7.3.0"
     graphlib: "npm:~2.1.8"
     jexl: "npm:~2.3.0"
-    nanoid: "npm:~5.1.0"
+    nanoid: "npm:~5.1.2"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
     yargs: "npm:~17.7.2"
   bin:
     ts-match: ./bin/ts-transform.js
     ts-transform: ./bin/ts-transform.js
-  checksum: 10c0/0f6e12498c3cf938019d3528ce83404e9e1a27aa8b580dac6c513cec000fef93d8b9f183942dc21a419c5ff5e63c02633f9a82575f6b53be5b995702055ad1e9
+  checksum: 10c0/fa0def31170e2342079c48d4e8d170f67b70ce9f7a431b9f70846a56c12c93d99e154527509ec36f163fd0e493c79eef3bfe44073880627ab79f77efa0a45707
   languageName: node
   linkType: hard
 
@@ -10271,9 +10185,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.27.7":
-  version: 0.27.7
-  resolution: "typedoc@npm:0.27.7"
+"typedoc@npm:~0.27.8":
+  version: 0.27.9
+  resolution: "typedoc@npm:0.27.9"
   dependencies:
     "@gerrit0/mini-shiki": "npm:^1.24.0"
     lunr: "npm:^2.3.9"
@@ -10281,10 +10195,10 @@ __metadata:
     minimatch: "npm:^9.0.5"
     yaml: "npm:^2.6.1"
   peerDependencies:
-    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
+    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/727f7da5255f66d949a524582b5ec9ecfa43caade1ea48efe9305117bd18d5a26c423c788767ee992662eff7bec7ac993673cafe14d6fd206881c604cad2f6ba
+  checksum: 10c0/999668d9d23e1824b762e2c411e2c0860d0ce4a2e61f23a2c31d36a1d6337a763553bc75205aee25ce34659e9315315c720694e9eccd7e7e4755873fdfec1192
   languageName: node
   linkType: hard
 
@@ -10312,6 +10226,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:~5.8.2":
+  version: 5.8.2
+  resolution: "typescript@npm:5.8.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/5c4f6fbf1c6389b6928fe7b8fcd5dc73bb2d58cd4e3883f1d774ed5bd83b151cbac6b7ecf11723de56d4676daeba8713894b1e9af56174f2f9780ae7848ec3c6
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
@@ -10319,6 +10243,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/6fd7e0ed3bf23a81246878c613423730c40e8bdbfec4c6e4d7bf1b847cbb39076e56ad5f50aa9d7ebd89877999abaee216002d3f2818885e41c907caaa192cc4
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A~5.8.2#optional!builtin<compat/typescript>":
+  version: 5.8.2
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/5448a08e595cc558ab321e49d4cac64fb43d1fa106584f6ff9a8d8e592111b373a995a1d5c7f3046211c8a37201eb6d0f1566f15cdb7a62a5e3be01d087848e2
   languageName: node
   linkType: hard
 
@@ -10487,12 +10421,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:~11.0.5":
-  version: 11.0.5
-  resolution: "uuid@npm:11.0.5"
+"uuid@npm:~11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
   bin:
     uuid: dist/esm/bin/uuid
-  checksum: 10c0/6f59f0c605e02c14515401084ca124b9cb462b4dcac866916a49862bcf831874508a308588c23a7718269226ad11a92da29b39d761ad2b86e736623e3a33b6e7
+  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 
@@ -10734,15 +10668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.6":
-  version: 1.7.6
-  resolution: "xlucene-parser@npm:1.7.6"
+"xlucene-parser@npm:~1.7.7":
+  version: 1.7.7
+  resolution: "xlucene-parser@npm:1.7.7"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.5"
+    "@terascope/utils": "npm:~1.7.6"
     peggy: "npm:~4.2.0"
     ts-pegjs: "npm:~4.2.1"
-  checksum: 10c0/0486419920c038e98de3464b19b9e75fbc49567f8af960d7f0d3eb3ab90dfdee1782038e7aaa1b8e0aa6bc0f8751d9511fce1934a8a9521286a2a361f8af3139
+  checksum: 10c0/cb8ce538fcb336f665aa699cc2ccc012fa98a62030aa22fd036fbd9455606c9975380c631e0ecfc75d3b55dad2045cef3bb19dfef875d748e50405198bec1a96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following packages:
# Standard-Asset
  - dependencies
    - @faker-js/faker from 9.5.0 to 9.5.1
    - @terascope/data-mate from 1.7.6 to 1.7.7
    - @terascope/job-components from 1.9.6 to 1.9.7
    - @terascope/teraslice-state-storage from 1.8.3 to 1.8.4
    - @terascope/utils from 1.7.5 to 1.7.6
    - ts-transforms from 1.7.6 to 1.7.7
# standard-assets-bundle
  - devDependencies
    - @terascope/eslint-config from 1.1.7 to 1.1.8
    - @terascope/job-components from 1.9.6 to 1.9.7
    - @terascope/scripts from 1.10.4 to 1.11.0
    - @types/node from 22.13.5 to 22.13.8
    - typescript from 5.7.3 to 5.8.2
# @terascope/standard-asset-apis
  - dependencies
    - @terascope/utils from 1.7.5 to 1.7.6
  - devDependencies
    - @terascope/scripts from 1.10.4 to 1.11.0
    - @types/node from 22.13.5 to 22.13.8
    - typescript from 5.7.3 to 5.8.2