### PR TITLE
bundled dependency updates 3-17-2025

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -22,11 +22,11 @@
     },
     "dependencies": {
         "@faker-js/faker": "~9.6.0",
-        "@terascope/data-mate": "~1.7.7",
-        "@terascope/job-components": "~1.9.7",
+        "@terascope/data-mate": "~1.7.8",
+        "@terascope/job-components": "~1.9.8",
         "@terascope/standard-asset-apis": "~1.0.3",
-        "@terascope/teraslice-state-storage": "~1.8.4",
-        "@terascope/utils": "~1.7.6",
+        "@terascope/teraslice-state-storage": "~1.8.5",
+        "@terascope/utils": "~1.7.7",
         "@types/chance": "~1.1.6",
         "@types/express": "~4.17.21",
         "chance": "~1.1.12",
@@ -37,7 +37,7 @@
         "randexp": "~0.5.3",
         "short-unique-id": "~5.2.0",
         "timsort": "~0.3.0",
-        "ts-transforms": "~1.7.7",
+        "ts-transforms": "~1.7.8",
         "tslib": "~2.8.1"
     },
     "devDependencies": {

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {
@@ -24,7 +24,7 @@
         "@faker-js/faker": "~9.6.0",
         "@terascope/data-mate": "~1.7.8",
         "@terascope/job-components": "~1.9.8",
-        "@terascope/standard-asset-apis": "~1.0.3",
+        "@terascope/standard-asset-apis": "~1.0.4",
         "@terascope/teraslice-state-storage": "~1.8.5",
         "@terascope/utils": "~1.7.7",
         "@types/chance": "~1.1.6",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.9",
-        "@terascope/job-components": "~1.9.7",
-        "@terascope/scripts": "~1.12.0",
+        "@terascope/eslint-config": "~1.1.10",
+        "@terascope/job-components": "~1.9.8",
+        "@terascope/scripts": "~1.13.0",
         "@terascope/standard-asset-apis": "~1.0.3",
         "@types/express": "~4.17.21",
         "@types/fs-extra": "~11.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "type": "module",
@@ -32,7 +32,7 @@
         "@terascope/eslint-config": "~1.1.10",
         "@terascope/job-components": "~1.9.8",
         "@terascope/scripts": "~1.13.0",
-        "@terascope/standard-asset-apis": "~1.0.3",
+        "@terascope/standard-asset-apis": "~1.0.4",
         "@types/express": "~4.17.21",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~29.5.14",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/standard-asset-apis",
     "displayName": "Standard Asset Apis",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "A common set of tools for data processing",
     "homepage": "https://github.com/terascope/standard-assets",
     "repository": "git@github.com:terascope/standard-assets.git",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,10 +22,10 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "~3.1.0",
-        "@terascope/utils": "~1.7.6"
+        "@terascope/utils": "~1.7.7"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.12.0",
+        "@terascope/scripts": "~1.13.0",
         "@types/jest": "~29.5.14",
         "@types/node": "~22.13.10",
         "jest": "~29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,7 +1301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/standard-asset-apis@npm:~1.0.3, @terascope/standard-asset-apis@workspace:packages/standard-asset-apis":
+"@terascope/standard-asset-apis@npm:~1.0.4, @terascope/standard-asset-apis@workspace:packages/standard-asset-apis":
   version: 0.0.0-use.local
   resolution: "@terascope/standard-asset-apis@workspace:packages/standard-asset-apis"
   dependencies:
@@ -9371,7 +9371,7 @@ __metadata:
     "@terascope/eslint-config": "npm:~1.1.10"
     "@terascope/job-components": "npm:~1.9.8"
     "@terascope/scripts": "npm:~1.13.0"
-    "@terascope/standard-asset-apis": "npm:~1.0.3"
+    "@terascope/standard-asset-apis": "npm:~1.0.4"
     "@types/express": "npm:~4.17.21"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~29.5.14"
@@ -9400,7 +9400,7 @@ __metadata:
     "@faker-js/faker": "npm:~9.6.0"
     "@terascope/data-mate": "npm:~1.7.8"
     "@terascope/job-components": "npm:~1.9.8"
-    "@terascope/standard-asset-apis": "npm:~1.0.3"
+    "@terascope/standard-asset-apis": "npm:~1.0.4"
     "@terascope/teraslice-state-storage": "npm:~1.8.5"
     "@terascope/utils": "npm:~1.7.7"
     "@types/chance": "npm:~1.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,14 +505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.21.0, @eslint/js@npm:~9.21.0":
-  version: 9.21.0
-  resolution: "@eslint/js@npm:9.21.0"
-  checksum: 10c0/86c24a2668808995037e3f40c758335df2ae277c553ac0cf84381a1a8698f3099d8a22dd9c388947e6b7f93fcc1142f62406072faaa2b83c43ca79993fc01bb3
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.22.0":
+"@eslint/js@npm:9.22.0, @eslint/js@npm:~9.22.0":
   version: 9.22.0
   resolution: "@eslint/js@npm:9.22.0"
   checksum: 10c0/5bcd009bb579dc6c6ed760703bdd741e08a48cd9decd677aa2cf67fe66236658cb09a00185a0369f3904e5cffba9e6e0f2ff4d9ba4fdf598fcd81d34c49213a5
@@ -1140,9 +1133,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~4.0.1":
-  version: 4.0.1
-  resolution: "@stylistic/eslint-plugin@npm:4.0.1"
+"@stylistic/eslint-plugin@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "@stylistic/eslint-plugin@npm:4.2.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.23.0"
     eslint-visitor-keys: "npm:^4.2.0"
@@ -1151,7 +1144,7 @@ __metadata:
     picomatch: "npm:^4.0.2"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/a1a875eaa43a494ce34d490f93f1e61e1b1dfb4d6fafaef54f1ad6db768a8758714e1e826946bd0e8d403af13d0d63820a50f089383f868199a44cd57bddc137
+  checksum: 10c0/d9b2b08635dc4a98ceb59b3768e58e31ecd65f3e727ca8ed2e3538027d9d3d649d43d62631688cda9087f39b3893950b2a11557ccae11cf55b783b20d3f19e4e
   languageName: node
   linkType: hard
 
@@ -1164,15 +1157,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.7.7":
-  version: 1.7.7
-  resolution: "@terascope/data-mate@npm:1.7.7"
+"@terascope/data-mate@npm:~1.7.8":
+  version: 1.7.8
+  resolution: "@terascope/data-mate@npm:1.7.8"
   dependencies:
-    "@terascope/data-types": "npm:~1.7.6"
+    "@terascope/data-types": "npm:~1.7.7"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.3.0"
+    awesome-phonenumber: "npm:~7.4.0"
     date-fns: "npm:~4.1.0"
     ip-bigint: "npm:~8.2.1"
     ip6addr: "npm:~0.2.5"
@@ -1183,47 +1176,47 @@ __metadata:
     uuid: "npm:~11.1.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.7.7"
-  checksum: 10c0/8d4e9291f0403fb374825791be31c49c196b605a92ef180ec1dbffa6050fc9806f6c58fe68661a698c185fbf1a346f39d0c90e18f78dd6c5abae31508645f7a9
+    xlucene-parser: "npm:~1.7.8"
+  checksum: 10c0/69e984678301ed0485375d26a342222506371def41fb27e0ffdbc96483a72a9bc3ee0a3545b0fd0f5e550bf3056f32415709cc6494b2d1f6e7f7d024f939bafb
   languageName: node
   linkType: hard
 
-"@terascope/data-types@npm:~1.7.6":
-  version: 1.7.6
-  resolution: "@terascope/data-types@npm:1.7.6"
+"@terascope/data-types@npm:~1.7.7":
+  version: 1.7.7
+  resolution: "@terascope/data-types@npm:1.7.7"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     graphql: "npm:~16.10.0"
     yargs: "npm:~17.7.2"
   bin:
     data-types: ./bin/data-types.js
-  checksum: 10c0/e3df1a54a14156e3b3ed8e518e4d6919c284347198cb410215f3347ee64be92fd2aa0ef231e373008f6d54aa95eedad4210c3021376c760f8d9cfe3a7ea35831
+  checksum: 10c0/d6097069a3045f3f8ffdbdc20ae3c8885c8c30c03ea4d049af11e155bb2f3df76608206d64dff9a3962a47775c3c3ec32d891af31ce36a5f346e085e0f02be92
   languageName: node
   linkType: hard
 
-"@terascope/elasticsearch-api@npm:~4.8.4":
-  version: 4.8.4
-  resolution: "@terascope/elasticsearch-api@npm:4.8.4"
+"@terascope/elasticsearch-api@npm:~4.8.5":
+  version: 4.8.5
+  resolution: "@terascope/elasticsearch-api@npm:4.8.5"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     bluebird: "npm:~3.7.2"
     setimmediate: "npm:~1.0.5"
-  checksum: 10c0/7fb8bd63d5e10adbf821ecbb331922cd196b0cb6fd8e7dce78cb29ee2a632b6624a82e48cdd68cf42cc5d1b51fddf09ac786d662cf0a7488fed61cafa71182ed
+  checksum: 10c0/693fa1a6dda70ac792d34b06b1669de0b416d66d08ec74fbcc7a7c734b293e93e6111bc4d138d407fdfa1a19f98ecdcd921cd5ae6fe4f47848df5e45ff86ff51
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.9":
-  version: 1.1.9
-  resolution: "@terascope/eslint-config@npm:1.1.9"
+"@terascope/eslint-config@npm:~1.1.10":
+  version: 1.1.10
+  resolution: "@terascope/eslint-config@npm:1.1.10"
   dependencies:
     "@eslint/compat": "npm:~1.2.7"
-    "@eslint/js": "npm:~9.21.0"
-    "@stylistic/eslint-plugin": "npm:~4.0.1"
-    "@typescript-eslint/eslint-plugin": "npm:~8.25.0"
-    "@typescript-eslint/parser": "npm:~8.25.0"
-    eslint: "npm:~9.21.0"
+    "@eslint/js": "npm:~9.22.0"
+    "@stylistic/eslint-plugin": "npm:~4.2.0"
+    "@typescript-eslint/eslint-plugin": "npm:~8.26.0"
+    "@typescript-eslint/parser": "npm:~8.26.0"
+    eslint: "npm:~9.22.0"
     eslint-plugin-import: "npm:~2.31.0"
     eslint-plugin-jest: "npm:~28.11.0"
     eslint-plugin-jest-dom: "npm:~5.5.0"
@@ -1233,8 +1226,8 @@ __metadata:
     eslint-plugin-testing-library: "npm:~7.1.1"
     globals: "npm:~16.0.0"
     typescript: "npm:~5.8.2"
-    typescript-eslint: "npm:~8.25.0"
-  checksum: 10c0/80f3d2523c042834eeb4753808bbcca7b0483fd7bce7433b2bc0879c1ee82ccd83acc32ee87afee16cd93076adacf39a14a0523af24040e5ab9e548ac583c3d4
+    typescript-eslint: "npm:~8.26.0"
+  checksum: 10c0/05bae150eacbb0969941d119e41ff891b989c6707bc6ae24f07bccd6325d85bd609291ac4bc6de873269ecbecd5c54d05059181ec65e51b9050fb2b33e2d119f
   languageName: node
   linkType: hard
 
@@ -1253,12 +1246,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.9.7":
-  version: 1.9.7
-  resolution: "@terascope/job-components@npm:1.9.7"
+"@terascope/job-components@npm:~1.9.8":
+  version: 1.9.8
+  resolution: "@terascope/job-components@npm:1.9.8"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
@@ -1267,16 +1260,16 @@ __metadata:
     prom-client: "npm:~15.1.3"
     semver: "npm:~7.7.1"
     uuid: "npm:~11.1.0"
-  checksum: 10c0/77415109760c0b40fc72540c3eb9a0959c33ba16cf15acfd8f1adb2a6dfb13b4ab226fc5151ac460eaa96f7cc0baa045bb5c31887a6837620476f04ecea825f6
+  checksum: 10c0/3d5cfc42ed8fb09816b28cdf52690463e5f81e305e35b3c6c1a302d2b2020f99e869e58b7c05c2fc431bbd0f653f4bd7103061f974ef2ded0a680509b0432080
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.12.0":
-  version: 1.12.0
-  resolution: "@terascope/scripts@npm:1.12.0"
+"@terascope/scripts@npm:~1.13.0":
+  version: 1.13.0
+  resolution: "@terascope/scripts@npm:1.13.0"
   dependencies:
     "@kubernetes/client-node": "npm:~0.22.3"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     codecov: "npm:~3.8.3"
     execa: "npm:~9.5.2"
     fs-extra: "npm:~11.3.0"
@@ -1304,7 +1297,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/96fa8db1cac32c1b1c8b0807e20da8724329a24dbfc542b29bc5e283cdc0128673c0e1d650000d7e70ad200730771ddc3a042196460a6f7789623c5b0ab375d9
+  checksum: 10c0/79b9534d813b390348504f9667f2baec3945be128be5ea3a8856825e9c222d353deef8c3e11cbafa476b136bd90af87f6e53fadaaad603f65994c80b6301739c
   languageName: node
   linkType: hard
 
@@ -1313,8 +1306,8 @@ __metadata:
   resolution: "@terascope/standard-asset-apis@workspace:packages/standard-asset-apis"
   dependencies:
     "@sindresorhus/fnv1a": "npm:~3.1.0"
-    "@terascope/scripts": "npm:~1.12.0"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/scripts": "npm:~1.13.0"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/jest": "npm:~29.5.14"
     "@types/node": "npm:~22.13.10"
     jest: "npm:~29.7.0"
@@ -1325,13 +1318,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-state-storage@npm:~1.8.4":
-  version: 1.8.4
-  resolution: "@terascope/teraslice-state-storage@npm:1.8.4"
+"@terascope/teraslice-state-storage@npm:~1.8.5":
+  version: 1.8.5
+  resolution: "@terascope/teraslice-state-storage@npm:1.8.5"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.8.4"
-    "@terascope/utils": "npm:~1.7.6"
-  checksum: 10c0/dee9a44f6adbfa9e6d69e66d9209c6a81565be421f0b94a9e4b76c3c76355318ac58e6085993e6f1c924ecffea0be9266e5d61c8c29e046c79bc61cb2311105a
+    "@terascope/elasticsearch-api": "npm:~4.8.5"
+    "@terascope/utils": "npm:~1.7.7"
+  checksum: 10c0/8ad9fc4859ad2da1e296b9377f5e2f1d7e606cfa0732cb3e09916661bb9c5a6b31cd5767febd990a4cebb53760692ad9bbaf100258f0ebac71ec644bed3bae2c
   languageName: node
   linkType: hard
 
@@ -1344,9 +1337,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.7.6":
-  version: 1.7.6
-  resolution: "@terascope/utils@npm:1.7.6"
+"@terascope/utils@npm:~1.7.7":
+  version: 1.7.7
+  resolution: "@terascope/utils@npm:1.7.7"
   dependencies:
     "@chainsafe/is-ip": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.1"
@@ -1364,7 +1357,7 @@ __metadata:
     "@turf/line-to-polygon": "npm:~7.2.0"
     "@types/lodash-es": "npm:~4.17.12"
     "@types/validator": "npm:~13.12.2"
-    awesome-phonenumber: "npm:~7.3.0"
+    awesome-phonenumber: "npm:~7.4.0"
     date-fns: "npm:~4.1.0"
     date-fns-tz: "npm:~3.2.0"
     datemath-parser: "npm:~1.0.6"
@@ -1384,7 +1377,7 @@ __metadata:
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
-  checksum: 10c0/b5c2d558e235f39936f9956bf7332790b2b95bdb1783c3950fe71d5a1d8edc8245546d1922ab5e32219a23fd34ce8cd3445752cde4f901a7b1a09a1b1685ece1
+  checksum: 10c0/ed117a340200600b33a37d9641cef7933bd2883fe9f64c186afd76eb85ce7990b2b60a38987a527e5eefe4f801616dc33b19ed0396bfcdd9a4ccc4fb8a43b81a
   languageName: node
   linkType: hard
 
@@ -2043,15 +2036,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.25.0, @typescript-eslint/eslint-plugin@npm:~8.25.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.25.0"
+"@typescript-eslint/eslint-plugin@npm:8.26.1, @typescript-eslint/eslint-plugin@npm:~8.26.0":
+  version: 8.26.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.26.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.25.0"
-    "@typescript-eslint/type-utils": "npm:8.25.0"
-    "@typescript-eslint/utils": "npm:8.25.0"
-    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.1"
+    "@typescript-eslint/type-utils": "npm:8.26.1"
+    "@typescript-eslint/utils": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
@@ -2059,24 +2052,24 @@ __metadata:
   peerDependencies:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/11d63850f5f03b29cd31166f8da111788dc74e46877c2e16a5c488d6c4aa4b6c68c0857b9a396ad920aa7f0f3e7166f4faecbb194c19cd2bb9d3f687c5d2b292
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/412f41aafd503a1faea91edd03a68717ca8a49ed6683700b8386115c67b86110c9826d10005d3a0341b78cdee41a6ef08842716ced2b58af03f91eb1b8cc929c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.25.0, @typescript-eslint/parser@npm:~8.25.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/parser@npm:8.25.0"
+"@typescript-eslint/parser@npm:8.26.1, @typescript-eslint/parser@npm:~8.26.0":
+  version: 8.26.1
+  resolution: "@typescript-eslint/parser@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.25.0"
-    "@typescript-eslint/types": "npm:8.25.0"
-    "@typescript-eslint/typescript-estree": "npm:8.25.0"
-    "@typescript-eslint/visitor-keys": "npm:8.25.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.1"
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/typescript-estree": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/9a54539ba297791f23093ff42a885cc57d36b26205d7a390e114d1f01cc584ce91ac6ead01819daa46b48f873cac6c829fcf399a436610bdbfa98e5cd78148a2
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/21fe4306b6017bf183d92cdd493edacd302816071e29e1400452f3ccd224ab8111b75892507b9731545e98e6e4d153e54dab568b3433f6c9596b6cb2f7af922f
   languageName: node
   linkType: hard
 
@@ -2100,6 +2093,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.26.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
+  checksum: 10c0/ecd30eb615c7384f01cea8f2c8e8dda7507ada52ad0d002d3701bdd9d06f6d14cefb31c6c26ef55708adfaa2045a01151e8685656240268231a4bac8f792afe4
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.4.0":
   version: 8.4.0
   resolution: "@typescript-eslint/scope-manager@npm:8.4.0"
@@ -2110,18 +2113,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.25.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/type-utils@npm:8.25.0"
+"@typescript-eslint/type-utils@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/type-utils@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.25.0"
-    "@typescript-eslint/utils": "npm:8.25.0"
+    "@typescript-eslint/typescript-estree": "npm:8.26.1"
+    "@typescript-eslint/utils": "npm:8.26.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.0.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/b7477a2d239cfd337f7d28641666763cf680a43a8d377a09dc42415f715670d35fbb4e772e103dfe8cd620c377e66bce740106bb3983ee65a739c28fab7325d1
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/17553b4333246e1ffd447dab78a4cbc565c129c9baf32326387760c9790120a99d955acf84888b7ef96e73c82fc22a3e08e80f0bd65d21e3cf2fe002f977aba1
   languageName: node
   linkType: hard
 
@@ -2136,6 +2139,13 @@ __metadata:
   version: 8.25.0
   resolution: "@typescript-eslint/types@npm:8.25.0"
   checksum: 10c0/b39addbee4be4d66e3089c2d01f9f1d69cedc13bff20e4fa9ed0ca5a0e7591d7c6e41ab3763c8c35404f971bc0fbf9f7867dbc2832740e5b63ee0049d60289f5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/types@npm:8.26.1"
+  checksum: 10c0/805b239b57854fc12eae9e2bec6ccab24bac1d30a762c455f22c73b777a5859c64c58b4750458bd0ab4aadd664eb95cbef091348a071975acac05b15ebea9f1b
   languageName: node
   linkType: hard
 
@@ -2183,6 +2193,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.26.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/visitor-keys": "npm:8.26.1"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/adc95e4735a8ded05ad35d7b4fae68c675afdd4b3531bc4a51eab5efe793cf80bc75f56dfc8022af4c0a5b316eec61f8ce6b77c2ead45fc675fea7e28cd52ade
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:8.4.0":
   version: 8.4.0
   resolution: "@typescript-eslint/typescript-estree@npm:8.4.0"
@@ -2202,18 +2230,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.25.0, @typescript-eslint/utils@npm:^8.23.0":
-  version: 8.25.0
-  resolution: "@typescript-eslint/utils@npm:8.25.0"
+"@typescript-eslint/utils@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/utils@npm:8.26.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.25.0"
-    "@typescript-eslint/types": "npm:8.25.0"
-    "@typescript-eslint/typescript-estree": "npm:8.25.0"
+    "@typescript-eslint/scope-manager": "npm:8.26.1"
+    "@typescript-eslint/types": "npm:8.26.1"
+    "@typescript-eslint/typescript-estree": "npm:8.26.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/cd15c4919f02899fd3975049a0a051a1455332a108c085a3e90ae9872e2cddac7f20a9a2c616f1366fca84274649e836ad6a437c9c5ead0bdabf5a123d12403f
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/a5cb3bdf253cc8e8474a2ed8666c0a6194abe56f44039c6623bef0459ed17d0276ed6e40c70d35bd8ec4d41bafc255e4d3025469f32ac692ba2d89e7579c2a26
   languageName: node
   linkType: hard
 
@@ -2248,6 +2276,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.23.0":
+  version: 8.25.0
+  resolution: "@typescript-eslint/utils@npm:8.25.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.25.0"
+    "@typescript-eslint/types": "npm:8.25.0"
+    "@typescript-eslint/typescript-estree": "npm:8.25.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 10c0/cd15c4919f02899fd3975049a0a051a1455332a108c085a3e90ae9872e2cddac7f20a9a2c616f1366fca84274649e836ad6a437c9c5ead0bdabf5a123d12403f
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:8.17.0":
   version: 8.17.0
   resolution: "@typescript-eslint/visitor-keys@npm:8.17.0"
@@ -2265,6 +2308,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.25.0"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/7eb84c5899a25b1eb89d3c3f4be3ff18171f934669c57e2530b6dfa5fdd6eaae60629f3c89d06f4c8075fd1c701de76c0b9194e2922895c661ab6091e48f7db9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.26.1":
+  version: 8.26.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.26.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.26.1"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: 10c0/51b1016d06cd2b9eac0a213de418b0a26022fd3b71478014541bfcbc2a3c4d666552390eb9c209fa9e52c868710d9f1b21a2c789d35c650239438c366a27a239
   languageName: node
   linkType: hard
 
@@ -2645,10 +2698,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"awesome-phonenumber@npm:~7.3.0":
-  version: 7.3.0
-  resolution: "awesome-phonenumber@npm:7.3.0"
-  checksum: 10c0/b64366168e56ae106d7c89363f1a6a013dc6456ed62eea507a2ecdec2d0e9fd305700c6fa6d6842b82e38aa9bec13a84ed1093cc5b12c65edfef9361aab60b9a
+"awesome-phonenumber@npm:~7.4.0":
+  version: 7.4.0
+  resolution: "awesome-phonenumber@npm:7.4.0"
+  checksum: 10c0/294fe6c291799198ecd30f386da6702e61b804b68635bccc762f41a6f7da6b84bda3ba8722b164b3aa3e255c746554f705d2f8b300e4436041dddf613f9aa2f0
   languageName: node
   linkType: hard
 
@@ -4286,16 +4339,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "eslint-scope@npm:8.2.0"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^5.2.0"
-  checksum: 10c0/8d2d58e2136d548ac7e0099b1a90d9fab56f990d86eb518de1247a7066d38c908be2f3df477a79cf60d70b30ba18735d6c6e70e9914dca2ee515a729975d70d6
-  languageName: node
-  linkType: hard
-
 "eslint-scope@npm:^8.3.0":
   version: 8.3.0
   resolution: "eslint-scope@npm:8.3.0"
@@ -4317,55 +4360,6 @@ __metadata:
   version: 4.2.0
   resolution: "eslint-visitor-keys@npm:4.2.0"
   checksum: 10c0/2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.21.0":
-  version: 9.21.0
-  resolution: "eslint@npm:9.21.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.19.2"
-    "@eslint/core": "npm:^0.12.0"
-    "@eslint/eslintrc": "npm:^3.3.0"
-    "@eslint/js": "npm:9.21.0"
-    "@eslint/plugin-kit": "npm:^0.2.7"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.2.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/558edb25b440cd51825d66fed3e84f1081bd6f4cb2cf994e60ece4c5978fa0583e88b75faf187c1fc21688c4ff7072f12bf5f6d1be1e09a4d6af78cff39dc520
   languageName: node
   linkType: hard
 
@@ -7614,12 +7608,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:~5.1.2":
-  version: 5.1.2
-  resolution: "nanoid@npm:5.1.2"
+"nanoid@npm:~5.1.3":
+  version: 5.1.4
+  resolution: "nanoid@npm:5.1.4"
   bin:
     nanoid: bin/nanoid.js
-  checksum: 10c0/60b3d30d1629704f4b156f79e53a454d10440a38f4ab14cda1c9aa08091389212d03afb35fbc09c11f4619f83bcf5076abc4719295e3b79c57abad0e40297177
+  checksum: 10c0/a911892e2d51a84850a0c333a6c2603617ad2e383f1b35343f8017346e2b46a171902617ae60636bfbb7d8479e1659b6143f9f1b21c83988d2ed93a22cfb4271
   languageName: node
   linkType: hard
 
@@ -9374,9 +9368,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "standard-assets-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.9"
-    "@terascope/job-components": "npm:~1.9.7"
-    "@terascope/scripts": "npm:~1.12.0"
+    "@terascope/eslint-config": "npm:~1.1.10"
+    "@terascope/job-components": "npm:~1.9.8"
+    "@terascope/scripts": "npm:~1.13.0"
     "@terascope/standard-asset-apis": "npm:~1.0.3"
     "@types/express": "npm:~4.17.21"
     "@types/fs-extra": "npm:~11.0.4"
@@ -9404,11 +9398,11 @@ __metadata:
   resolution: "standard@workspace:asset"
   dependencies:
     "@faker-js/faker": "npm:~9.6.0"
-    "@terascope/data-mate": "npm:~1.7.7"
-    "@terascope/job-components": "npm:~1.9.7"
+    "@terascope/data-mate": "npm:~1.7.8"
+    "@terascope/job-components": "npm:~1.9.8"
     "@terascope/standard-asset-apis": "npm:~1.0.3"
-    "@terascope/teraslice-state-storage": "npm:~1.8.4"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/teraslice-state-storage": "npm:~1.8.5"
+    "@terascope/utils": "npm:~1.7.7"
     "@types/chance": "npm:~1.1.6"
     "@types/express": "npm:~4.17.21"
     "@types/ms": "npm:^0.7.34"
@@ -9420,7 +9414,7 @@ __metadata:
     randexp: "npm:~0.5.3"
     short-unique-id: "npm:~5.2.0"
     timsort: "npm:~0.3.0"
-    ts-transforms: "npm:~1.7.7"
+    ts-transforms: "npm:~1.7.8"
     tslib: "npm:~2.8.1"
   languageName: unknown
   linkType: soft
@@ -9980,24 +9974,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-transforms@npm:~1.7.7":
-  version: 1.7.7
-  resolution: "ts-transforms@npm:1.7.7"
+"ts-transforms@npm:~1.7.8":
+  version: 1.7.8
+  resolution: "ts-transforms@npm:1.7.8"
   dependencies:
-    "@terascope/data-mate": "npm:~1.7.7"
+    "@terascope/data-mate": "npm:~1.7.8"
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
-    awesome-phonenumber: "npm:~7.3.0"
+    "@terascope/utils": "npm:~1.7.7"
+    awesome-phonenumber: "npm:~7.4.0"
     graphlib: "npm:~2.1.8"
     jexl: "npm:~2.3.0"
-    nanoid: "npm:~5.1.2"
+    nanoid: "npm:~5.1.3"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
     yargs: "npm:~17.7.2"
   bin:
     ts-match: ./bin/ts-transform.js
     ts-transform: ./bin/ts-transform.js
-  checksum: 10c0/fa0def31170e2342079c48d4e8d170f67b70ce9f7a431b9f70846a56c12c93d99e154527509ec36f163fd0e493c79eef3bfe44073880627ab79f77efa0a45707
+  checksum: 10c0/9c2018c7ffba64a6307788810da211a6e4fbf4d709a6bfd9eed540cf710ba9a1221b88664a477fc810071bc397b3595994b14239f80b9621ea6168e211436172
   languageName: node
   linkType: hard
 
@@ -10216,17 +10210,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.25.0":
-  version: 8.25.0
-  resolution: "typescript-eslint@npm:8.25.0"
+"typescript-eslint@npm:~8.26.0":
+  version: 8.26.1
+  resolution: "typescript-eslint@npm:8.26.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.25.0"
-    "@typescript-eslint/parser": "npm:8.25.0"
-    "@typescript-eslint/utils": "npm:8.25.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.26.1"
+    "@typescript-eslint/parser": "npm:8.26.1"
+    "@typescript-eslint/utils": "npm:8.26.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/bdc1165be1bc60311045ca69aa1bff4bbb7feac906c6b7885c4bc859693d8ca1b88840a1ba10b226ca2343c4bd7388b7a36e5c787b0d7f1bab5ababb80e783cc
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/92ab2e59950020eae9956e0e1fd572bc98bab0f764e63f49bfd9feab3b38edfe888712fd2df6fc43642b9be06e60288f72626d7a7cc25dcbb4c692df64cba064
   languageName: node
   linkType: hard
 
@@ -10662,15 +10656,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.7.7":
-  version: 1.7.7
-  resolution: "xlucene-parser@npm:1.7.7"
+"xlucene-parser@npm:~1.7.8":
+  version: 1.7.8
+  resolution: "xlucene-parser@npm:1.7.8"
   dependencies:
     "@terascope/types": "npm:~1.4.1"
-    "@terascope/utils": "npm:~1.7.6"
+    "@terascope/utils": "npm:~1.7.7"
     peggy: "npm:~4.2.0"
     ts-pegjs: "npm:~4.2.1"
-  checksum: 10c0/cb8ce538fcb336f665aa699cc2ccc012fa98a62030aa22fd036fbd9455606c9975380c631e0ecfc75d3b55dad2045cef3bb19dfef875d748e50405198bec1a96
+  checksum: 10c0/d9e51a57f19321f9f59b3d99c6041c9a2c18a433b7e216eff8970087685807febd79bc28b4c795548abc29087dfdf51a332435391e05949063ba7bf1d69c706e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following packages:
## standard from 1.3.3 to 1.3.4
  - dependencies
    - @terascope/data-mate from 1.7.7 to 1.7.8
    - @terascope/job-components from 1.9.7 to 1.9.8
    - @terascope/standard-asset-apis from 1.0.3 to 1.0.4
    - @terascope/teraslice-state-storage from 1.8.4 to 1.8.5
    - @terascope/utils from 1.7.6 to 1.7.7
    - ts-transforms from 1.7.7 to 1.7.8
## standard-assets-bundle from 1.3.3 to 1.3.4
  - devDependencies
    - @terascope/eslint-config from 1.1.9 to 1.1.10
    - @terascope/job-components from 1.9.7 to 1.9.8
    - @terascope/scripts from 1.12.0 to 1.13.0
    - @terascope/standard-asset-apis from 1.0.3 to 1.0.4
## @terascope/standard-asset-apis from 1.0.3 to 1.0.4
  - dependencies
    - @terascope/utils from 1.7.6 to 1.7.7"
  - devDependencies
    - @terascope/scripts from 1.12.0 to 1.13.0

