### PR TITLE
[website] fix algolia doc search, correct links on help page

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -148,7 +148,8 @@ module.exports = {
         algolia: {
             appId: 'KD1DQTOI4M',
             apiKey: '39a27eca4d31c921b2b412344351996e',
-            indexName: 'terascope_teraslice_standard-assets'
+            indexName: 'terascope_teraslice_standard-assets',
+            contextualSearch: false
         },
         mermaid: {
             theme: {

--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -30,11 +30,11 @@ function Help() {
       title: 'Browse Docs',
     },
     {
-      content: '[Ask questions](https://github.com/terascope/kafka-assets/issues) about the documentation and project',
+      content: '[Ask questions](https://github.com/terascope/standard-assets/issues) about the documentation and project',
       title: 'Join the community',
     },
     {
-      content: '[Find out](https://github.com/terascope/kafka-assets/releases) what\'s new with this project',
+      content: '[Find out](https://github.com/terascope/standard-assets/releases) what\'s new with this project',
       title: 'Stay up to date',
     },
   ];


### PR DESCRIPTION
This PR makes the following changes:
- adds `contextualSearch: false` to the algolia settings, which was defaulting to true and preventing the whole website from being searched.
- a few links on the help page are corrected
- Bump asset version from v1.3.5 to 1.3.6