### PR TITLE
fix illegal character in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ teraslice-cli assets deploy localhost --build
 
 ## Documentation
 
-<https://terascope.github.io/standard-assets/>
+https://terascope.github.io/standard-assets/
 
 ## Operations
 

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",


### PR DESCRIPTION
Release 1.4.1 failed to build docs because of an illegal character in README.md. This PR fixes the README.md and bumps the asset to v1.4.1 to build the docs again.