### PR TITLE
[website, CI]temporarily add api docs to git staging area while building website

### DIFF
--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -27,9 +27,11 @@ main() {
 
     yarn setup &&
         yarn docs &&
+        git add -f docs/packages/*/api &&
         cd website &&
         yarn install  &&
-        yarn run build
+        yarn run build &&
+        git restore --staged ../docs/packages/*/api
 }
 
 main "$@"


### PR DESCRIPTION
This PR changes the `scripts/build-documentation.sh` script to force add `docs/packages/*/api` to the git staging area, then remove them after the docusaurus site builds. In some cases the website build will fail if the files do not have a git history.