### PR TITLE
Bundled dependency updates for 6-23-2025

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {
@@ -24,7 +24,7 @@
         "@faker-js/faker": "~9.8.0",
         "@terascope/data-mate": "~1.8.4",
         "@terascope/job-components": "~1.10.3",
-        "@terascope/standard-asset-apis": "~1.0.5",
+        "@terascope/standard-asset-apis": "~1.0.6",
         "@terascope/teraslice-state-storage": "~1.9.3",
         "@terascope/types": "~1.4.1",
         "@terascope/utils": "~1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",
@@ -37,7 +37,7 @@
         "@terascope/eslint-config": "~1.1.18",
         "@terascope/job-components": "~1.10.3",
         "@terascope/scripts": "~1.18.1",
-        "@terascope/standard-asset-apis": "~1.0.5",
+        "@terascope/standard-asset-apis": "~1.0.6",
         "@types/express": "~5.0.3",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/standard-asset-apis",
     "displayName": "Standard Asset Apis",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "A common set of tools for data processing",
     "homepage": "https://github.com/terascope/standard-assets",
     "repository": "git@github.com:terascope/standard-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,7 +1662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/standard-asset-apis@npm:~1.0.5, @terascope/standard-asset-apis@workspace:packages/standard-asset-apis":
+"@terascope/standard-asset-apis@npm:~1.0.6, @terascope/standard-asset-apis@workspace:packages/standard-asset-apis":
   version: 0.0.0-use.local
   resolution: "@terascope/standard-asset-apis@workspace:packages/standard-asset-apis"
   dependencies:
@@ -9966,7 +9966,7 @@ __metadata:
     "@terascope/eslint-config": "npm:~1.1.18"
     "@terascope/job-components": "npm:~1.10.3"
     "@terascope/scripts": "npm:~1.18.1"
-    "@terascope/standard-asset-apis": "npm:~1.0.5"
+    "@terascope/standard-asset-apis": "npm:~1.0.6"
     "@types/express": "npm:~5.0.3"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
@@ -9995,7 +9995,7 @@ __metadata:
     "@faker-js/faker": "npm:~9.8.0"
     "@terascope/data-mate": "npm:~1.8.4"
     "@terascope/job-components": "npm:~1.10.3"
-    "@terascope/standard-asset-apis": "npm:~1.0.5"
+    "@terascope/standard-asset-apis": "npm:~1.0.6"
     "@terascope/teraslice-state-storage": "npm:~1.9.3"
     "@terascope/types": "npm:~1.4.1"
     "@terascope/utils": "npm:~1.8.3"


### PR DESCRIPTION
This PR updates the following packages:
# standard from 1.5.1 to 1.5.2
  - dependencies
    - @terascope/data-mate from 1.8.3 to 1.8.4
    - @terascope/job-components from 1.10.2 to 1.10.3
    - @terascope/standard-asset-apis from 1.0.5 to 1.0.6
    - @terascope/teraslice-state-storage from 1.9.2 to 1.9.3
    - @terascope/utils from 1.8.2 to 1.8.3
    - ts-transforms from 1.8.4 to 1.8.5
# standard-assets-bundle from 1.5.1 to 1.5.2
  - devDependencies
    - @terascope/eslint-config from 1.1.17 to 1.1.18
    - @terascope/job-components from 1.10.2 to 1.10.3
    - @terascope/scripts from 1.18.0 to 1.18.1
    - @terascope/standard-asset-apis from 1.0.5 to 1.0.6
    - jest from 30.0.0 to 30.0.2
# @terascope/standard-asset-apis from 1.0.5 to 1.0.6
  - dependencies
    - @terascope/utils from 1.8.2 to 1.8.3
  - devDependencies
    - @terascope/scripts from 1.18.0 to 1.18.1
    - jest from 30.0.0 to 30.0.2