### PR TITLE
Add error handling to routed_sender

### DIFF
--- a/packages/standard-asset-apis/src/RoutedSender.ts
+++ b/packages/standard-asset-apis/src/RoutedSender.ts
@@ -321,51 +321,55 @@ export class RoutedSender {
     ): Promise<number> {
         let affectedRows = 0;
 
-        await pMap(this.allBatches.entries(), async ([route, batches]) => {
-            if (!batches.length) return;
+        try {
+            await pMap(this.allBatches.entries(), async ([route, batches]) => {
+                if (!batches.length) return;
 
-            this.allBatches.set(route, []);
+                this.allBatches.set(route, []);
 
-            await pMap(batches, async (batch) => {
-                if (batch.length <= minPerBatch) {
-                    batch.forEach((record) => {
-                        this.allBatches.set(
-                            route,
-                            addRecordToBatch(
-                                this.allBatches.get(route)!, record, this.batchSize
-                            )
-                        );
-                    });
-                    return;
-                }
+                await pMap(batches, async (batch) => {
+                    if (batch.length <= minPerBatch) {
+                        batch.forEach((record) => {
+                            this.allBatches.set(
+                                route,
+                                addRecordToBatch(
+                                    this.allBatches.get(route)!, record, this.batchSize
+                                )
+                            );
+                        });
+                        return;
+                    }
 
-                const batchId = ++this._batchId;
-                this.batchStartHook && await this.batchStartHook(batchId, route, batch.length);
+                    const batchId = ++this._batchId;
+                    this.batchStartHook && await this.batchStartHook(batchId, route, batch.length);
 
-                this.logger.debug(`Sending ${batch.length} records to route ${route}`);
+                    this.logger.debug(`Sending ${batch.length} records to route ${route}`);
 
-                const sender = this.senders.get(route);
-                if (!sender) throw new Error('No sender registered for route');
+                    const sender = this.senders.get(route);
+                    if (!sender) throw new Error('No sender registered for route');
 
-                const result: unknown = await sender.send(batch);
-                let affectedBatchCount: number;
-                if (isInteger(result)) {
-                    affectedBatchCount = result;
-                } else {
-                    // we do this for backwards compatibility
-                    affectedBatchCount = batch.length;
-                }
-                affectedRows += affectedBatchCount;
+                    const result: unknown = await sender.send(batch);
+                    let affectedBatchCount: number;
+                    if (isInteger(result)) {
+                        affectedBatchCount = result;
+                    } else {
+                        // we do this for backwards compatibility
+                        affectedBatchCount = batch.length;
+                    }
+                    affectedRows += affectedBatchCount;
 
-                this.batchEndHook && await this.batchEndHook(batchId, route, affectedBatchCount);
+                    this.batchEndHook && await this.batchEndHook(batchId, route, affectedBatchCount);
+                }, {
+                    stopOnError: false,
+                    concurrency: this.concurrencyPerStorage
+                });
             }, {
                 stopOnError: false,
-                concurrency: this.concurrencyPerStorage
+                concurrency: this.concurrencyAllStorage
             });
-        }, {
-            stopOnError: false,
-            concurrency: this.concurrencyAllStorage
-        });
+        } catch(err) {
+            throw new Error(`routed_sender failed to send records to their destinations: ${err}`);
+        }
 
         return affectedRows;
     }

--- a/packages/standard-asset-apis/src/RoutedSender.ts
+++ b/packages/standard-asset-apis/src/RoutedSender.ts
@@ -358,7 +358,8 @@ export class RoutedSender {
                     }
                     affectedRows += affectedBatchCount;
 
-                    this.batchEndHook && await this.batchEndHook(batchId, route, affectedBatchCount);
+                    this.batchEndHook
+                    && await this.batchEndHook(batchId, route, affectedBatchCount);
                 }, {
                     stopOnError: false,
                     concurrency: this.concurrencyPerStorage
@@ -367,7 +368,7 @@ export class RoutedSender {
                 stopOnError: false,
                 concurrency: this.concurrencyAllStorage
             });
-        } catch(err) {
+        } catch (err) {
             throw new Error(`routed_sender failed to send records to their destinations: ${err}`);
         }
 


### PR DESCRIPTION
This PR makes the following changes:

- Adds error handling to the `routed_sender` send() function for better user feedback

Todo: update scripts with local changes and bump

ref to issue #1114 