### PR TITLE
bundled dependency updates for 9-15-2025

### DIFF
--- a/asset/package.json
+++ b/asset/package.json
@@ -22,12 +22,12 @@
     },
     "dependencies": {
         "@faker-js/faker": "~10.0.0",
-        "@terascope/data-mate": "~1.12.0",
-        "@terascope/job-components": "~1.12.2",
+        "@terascope/data-mate": "~1.12.1",
+        "@terascope/job-components": "~1.12.3",
         "@terascope/standard-asset-apis": "~1.1.1",
-        "@terascope/teraslice-state-storage": "~1.12.2",
+        "@terascope/teraslice-state-storage": "~1.13.0",
         "@terascope/types": "~1.4.4",
-        "@terascope/utils": "~1.10.2",
+        "@terascope/utils": "~1.10.3",
         "@types/chance": "~1.1.7",
         "@types/express": "~5.0.3",
         "chance": "~1.1.13",
@@ -38,7 +38,7 @@
         "randexp": "~0.5.3",
         "short-unique-id": "~5.3.2",
         "timsort": "~0.3.0",
-        "ts-transforms": "~1.12.0",
+        "ts-transforms": "~1.12.1",
         "tslib": "~2.8.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
         "test:watch": "ts-scripts test --watch asset --"
     },
     "devDependencies": {
-        "@terascope/eslint-config": "~1.1.24",
-        "@terascope/job-components": "~1.12.2",
-        "@terascope/scripts": "~1.21.5",
+        "@terascope/eslint-config": "~1.1.25",
+        "@terascope/job-components": "~1.12.3",
+        "@terascope/scripts": "~1.21.6",
         "@terascope/standard-asset-apis": "~1.1.1",
         "@types/express": "~5.0.3",
         "@types/fs-extra": "~11.0.4",
         "@types/jest": "~30.0.0",
         "@types/json2csv": "~5.0.7",
-        "@types/node": "~24.3.1",
+        "@types/node": "~24.4.0",
         "@types/node-gzip": "~1.1.3",
         "@types/semver": "~7.7.1",
         "@types/timsort": "~0.3.3",
@@ -52,7 +52,7 @@
         "jest-extended": "~6.0.0",
         "node-notifier": "~10.0.1",
         "semver": "~7.7.2",
-        "teraslice-test-harness": "~1.3.7",
+        "teraslice-test-harness": "~1.3.8",
         "ts-jest": "~29.4.1",
         "tslib": "~2.8.1",
         "typescript": "~5.9.2"

--- a/packages/standard-asset-apis/package.json
+++ b/packages/standard-asset-apis/package.json
@@ -22,12 +22,12 @@
     },
     "dependencies": {
         "@sindresorhus/fnv1a": "~3.1.0",
-        "@terascope/utils": "~1.10.2"
+        "@terascope/utils": "~1.10.3"
     },
     "devDependencies": {
-        "@terascope/scripts": "~1.21.5",
+        "@terascope/scripts": "~1.21.6",
         "@types/jest": "~30.0.0",
-        "@types/node": "~24.3.1",
+        "@types/node": "~24.4.0",
         "jest": "~30.1.3",
         "jest-extended": "~6.0.0",
         "jest-fixtures": "~0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,7 +625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
+"@eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -721,14 +721,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.34.0, @eslint/js@npm:~9.34.0":
-  version: 9.34.0
-  resolution: "@eslint/js@npm:9.34.0"
-  checksum: 10c0/53f1bfd2a374683d9382a6850354555f6e89a88416c34a5d34e9fbbaf717e97c2b06300e8f93e5eddba8bda8951ccab7f93a680e56ded1a3d21d526019e69bab
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.35.0":
+"@eslint/js@npm:9.35.0, @eslint/js@npm:~9.35.0":
   version: 9.35.0
   resolution: "@eslint/js@npm:9.35.0"
   checksum: 10c0/d40fe38724bc76c085c0b753cdf937fa35c0d6807ae76b2632e3f5f66c3040c91adcf1aff2ce70b4f45752e60629fadc415eeec9af3be3c274bae1cac54b9840
@@ -1512,19 +1505,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~5.2.3":
-  version: 5.2.3
-  resolution: "@stylistic/eslint-plugin@npm:5.2.3"
+"@stylistic/eslint-plugin@npm:~5.3.1":
+  version: 5.3.1
+  resolution: "@stylistic/eslint-plugin@npm:5.3.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/types": "npm:^8.38.0"
+    "@typescript-eslint/types": "npm:^8.41.0"
     eslint-visitor-keys: "npm:^4.2.1"
     espree: "npm:^10.4.0"
     estraverse: "npm:^5.3.0"
     picomatch: "npm:^4.0.3"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/335cdb779e0afd2d2dc40ee58eb9f04c1d7ac51317c46834e3f0c0839746b8810a18af4268853a0f3c2b330976b9e5cf2753c3fac22a42e8976c0575602b2985
+  checksum: 10c0/806a96beae7744b37f5f60c9f3ed074f6abb64afe009d58d99f33b30723101d0c6ed9ccbcdbc1418c9e9842a46f689aa52fae67a44ce5c55b1540ad7218e6939
   languageName: node
   linkType: hard
 
@@ -1537,78 +1530,78 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/data-mate@npm:~1.12.0":
-  version: 1.12.0
-  resolution: "@terascope/data-mate@npm:1.12.0"
+"@terascope/data-mate@npm:~1.12.1":
+  version: 1.12.1
+  resolution: "@terascope/data-mate@npm:1.12.1"
   dependencies:
-    "@terascope/data-types": "npm:~1.11.2"
+    "@terascope/data-types": "npm:~1.11.3"
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     "@types/validator": "npm:~13.12.3"
     awesome-phonenumber: "npm:~7.5.0"
     big-json: "npm:^3.2.0"
     date-fns: "npm:~4.1.0"
-    ip-bigint: "npm:~8.2.1"
+    ip-bigint: "npm:~8.2.2"
     ip6addr: "npm:~0.2.5"
     ipaddr.js: "npm:~2.2.0"
     is-cidr: "npm:~6.0.0"
     jexl: "npm:~2.3.0"
     mnemonist: "npm:~0.40.3"
-    uuid: "npm:~11.1.0"
+    uuid: "npm:~12.0.0"
     valid-url: "npm:~1.0.9"
     validator: "npm:~13.12.0"
-    xlucene-parser: "npm:~1.10.2"
-  checksum: 10c0/4e31f3c3b5ed33fa6126d1a3d6df7f1d679987d64cb0d879248118a807fd95b61c235908d33b21b3124cc28d1e0eb990ba8ddbdbcad91c39c3e02981971afaba
+    xlucene-parser: "npm:~1.10.3"
+  checksum: 10c0/9f576b4e577f4d7dbfe828ec36e1280b4cfe72465f3acdd03aedad73b35119c38b6e3d2bb1f10054ff1ead7ae71803ee821fc1ad06a8484a0cbd0bb6ba139f75
   languageName: node
   linkType: hard
 
-"@terascope/data-types@npm:~1.11.2":
-  version: 1.11.2
-  resolution: "@terascope/data-types@npm:1.11.2"
+"@terascope/data-types@npm:~1.11.3":
+  version: 1.11.3
+  resolution: "@terascope/data-types@npm:1.11.3"
   dependencies:
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     graphql: "npm:~16.11.0"
     yargs: "npm:~18.0.0"
   bin:
     data-types: ./bin/data-types.js
-  checksum: 10c0/625e8bab2a06bac9e5fbb79f0c3a4ebceba7a56b23b3e771b1511a79df5206db46859bf48567730ae20a9bd2476ea0dcfd381a0bf425cfd96be10982fbaa6604
+  checksum: 10c0/937e9eaaa7adccf1ab83669a3f10e4980dc9137070b3cb734ef4065055ded513dbed9e220cfeae022cac26c52f58986f83d263b8b006b19df265a3cbbb814833
   languageName: node
   linkType: hard
 
-"@terascope/elasticsearch-api@npm:~4.12.2":
-  version: 4.12.2
-  resolution: "@terascope/elasticsearch-api@npm:4.12.2"
+"@terascope/elasticsearch-api@npm:~4.13.0":
+  version: 4.13.0
+  resolution: "@terascope/elasticsearch-api@npm:4.13.0"
   dependencies:
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     bluebird: "npm:~3.7.2"
     setimmediate: "npm:~1.0.5"
-  checksum: 10c0/f7ed3786afe55b3877008314735103023964a4d95290b77c36f32e1711bd4ce75f427e1da63f04fecf12b9609eb526e2cd8e32f46217428ef7d19437a7ef9d07
+  checksum: 10c0/c1e4f73876079f64034caa6495eee560827f6a60fce657e8d4d2c36b1969d840c7bfb6a3a3995a00c3e6144cb76db432728c7916c3b8d446b86a659129cbf678
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:~1.1.24":
-  version: 1.1.24
-  resolution: "@terascope/eslint-config@npm:1.1.24"
+"@terascope/eslint-config@npm:~1.1.25":
+  version: 1.1.25
+  resolution: "@terascope/eslint-config@npm:1.1.25"
   dependencies:
     "@eslint/compat": "npm:~1.3.2"
-    "@eslint/js": "npm:~9.34.0"
-    "@stylistic/eslint-plugin": "npm:~5.2.3"
-    "@typescript-eslint/eslint-plugin": "npm:~8.40.0"
-    "@typescript-eslint/parser": "npm:~8.40.0"
-    eslint: "npm:~9.34.0"
+    "@eslint/js": "npm:~9.35.0"
+    "@stylistic/eslint-plugin": "npm:~5.3.1"
+    "@typescript-eslint/eslint-plugin": "npm:~8.43.0"
+    "@typescript-eslint/parser": "npm:~8.43.0"
+    eslint: "npm:~9.35.0"
     eslint-plugin-import: "npm:~2.32.0"
     eslint-plugin-jest: "npm:~29.0.1"
     eslint-plugin-jest-dom: "npm:~5.5.0"
     eslint-plugin-jsx-a11y: "npm:~6.10.2"
     eslint-plugin-react: "npm:~7.37.5"
     eslint-plugin-react-hooks: "npm:~5.2.0"
-    eslint-plugin-testing-library: "npm:~7.6.6"
+    eslint-plugin-testing-library: "npm:~7.6.8"
     globals: "npm:~16.3.0"
     typescript: "npm:~5.9.2"
-    typescript-eslint: "npm:~8.40.0"
-  checksum: 10c0/5081f3d18ff3be0bf632f76f818832e48e2222b84d2cb24261c07d2374467aa47924deea326e34bf87cddcaa7fda01827019e897e3af8e4c699d962299a09d61
+    typescript-eslint: "npm:~8.43.0"
+  checksum: 10c0/e138bb89df2a9f3e8d9c8f9a782ff6c979dedceb52c14591e1bce52b58e6db05988b670b938719264dccac9a8670e61304992276f383de2256ac745cc8cf0e4e
   languageName: node
   linkType: hard
 
@@ -1627,34 +1620,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/job-components@npm:~1.12.2":
-  version: 1.12.2
-  resolution: "@terascope/job-components@npm:1.12.2"
+"@terascope/job-components@npm:~1.12.3":
+  version: 1.12.3
+  resolution: "@terascope/job-components@npm:1.12.3"
   dependencies:
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     convict: "npm:~6.2.4"
     convict-format-with-moment: "npm:~6.2.0"
     convict-format-with-validator: "npm:~6.2.0"
     datemath-parser: "npm:~1.0.6"
-    import-meta-resolve: "npm:~4.1.0"
+    import-meta-resolve: "npm:~4.2.0"
     prom-client: "npm:~15.1.3"
     semver: "npm:~7.7.2"
-    uuid: "npm:~11.1.0"
-  checksum: 10c0/e79513ec70b9ee5564ea1b12cb9cae1f58323e8e1d923e61843d6e42b4418f89e0c2d10624e5029ec11cbab51f1cedd699fab74f146518d7271ab06125b28998
+    uuid: "npm:~12.0.0"
+  checksum: 10c0/698b915d32872b9efe13c7459c5d3d96b3c9632e7f8a9373467752a51e90807c29ebae1d8d5bffc3318a09d25c33552a96b9724826e72c767f7f037281a3ea82
   languageName: node
   linkType: hard
 
-"@terascope/scripts@npm:~1.21.5":
-  version: 1.21.5
-  resolution: "@terascope/scripts@npm:1.21.5"
+"@terascope/scripts@npm:~1.21.6":
+  version: 1.21.6
+  resolution: "@terascope/scripts@npm:1.21.6"
   dependencies:
     "@kubernetes/client-node": "npm:~1.3.0"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     execa: "npm:~9.6.0"
     fs-extra: "npm:~11.3.1"
     globby: "npm:~14.1.0"
-    got: "npm:~14.4.7"
+    got: "npm:~14.4.8"
     ip: "npm:~2.0.1"
     js-yaml: "npm:~4.1.0"
     kafkajs: "npm:~2.2.4"
@@ -1667,7 +1660,7 @@ __metadata:
     signale: "npm:~1.4.0"
     sort-package-json: "npm:~3.4.0"
     toposort: "npm:~2.0.2"
-    typedoc: "npm:~0.28.11"
+    typedoc: "npm:~0.28.12"
     typedoc-plugin-markdown: "npm:~4.8.1"
     yaml: "npm:^2.8.1"
     yargs: "npm:~18.0.0"
@@ -1678,7 +1671,7 @@ __metadata:
       optional: true
   bin:
     ts-scripts: ./bin/ts-scripts.js
-  checksum: 10c0/e6ff8ddcf3b934eb5f25f883b27e0761e06656356cbde0d0e8830b3d111246ae92e0ce9ecc0611d0ffc92bc8cda8ba607810122def14ffccd1718278a23e6f92
+  checksum: 10c0/40aa7b988af8790950c0b0c7f69e4988b58f2adf2650e88029da69aee1148ae51dbe7422f925d58b6fe801469506debb1b5aa0364cbbc0ebdfceb1871aa1f64d
   languageName: node
   linkType: hard
 
@@ -1687,10 +1680,10 @@ __metadata:
   resolution: "@terascope/standard-asset-apis@workspace:packages/standard-asset-apis"
   dependencies:
     "@sindresorhus/fnv1a": "npm:~3.1.0"
-    "@terascope/scripts": "npm:~1.21.5"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/scripts": "npm:~1.21.6"
+    "@terascope/utils": "npm:~1.10.3"
     "@types/jest": "npm:~30.0.0"
-    "@types/node": "npm:~24.3.1"
+    "@types/node": "npm:~24.4.0"
     jest: "npm:~30.1.3"
     jest-extended: "npm:~6.0.0"
     jest-fixtures: "npm:~0.6.0"
@@ -1699,13 +1692,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terascope/teraslice-state-storage@npm:~1.12.2":
-  version: 1.12.2
-  resolution: "@terascope/teraslice-state-storage@npm:1.12.2"
+"@terascope/teraslice-state-storage@npm:~1.13.0":
+  version: 1.13.0
+  resolution: "@terascope/teraslice-state-storage@npm:1.13.0"
   dependencies:
-    "@terascope/elasticsearch-api": "npm:~4.12.2"
-    "@terascope/utils": "npm:~1.10.2"
-  checksum: 10c0/325513548626724da9ea5c248caf7782e986bf4b9e12c53c4cfe0bbb8510ac4e6cfa20945924e3d39e656e19ff88eab0cbeab2afc396c60f68554fdb833277c0
+    "@terascope/elasticsearch-api": "npm:~4.13.0"
+    "@terascope/utils": "npm:~1.10.3"
+  checksum: 10c0/433635f5b5d128fddd5ebedb5e1db849baf22a35a932d66c3915f63a652f7aeeb7c33c4eb135ed4b63d9ab56bae8461a17bfa5e5a4fdc317ae999ae9197e8ae6
   languageName: node
   linkType: hard
 
@@ -1718,9 +1711,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/utils@npm:~1.10.2":
-  version: 1.10.2
-  resolution: "@terascope/utils@npm:1.10.2"
+"@terascope/utils@npm:~1.10.3":
+  version: 1.10.3
+  resolution: "@terascope/utils@npm:1.10.3"
   dependencies:
     "@chainsafe/is-ip": "npm:~2.1.0"
     "@terascope/types": "npm:~1.4.4"
@@ -1744,7 +1737,7 @@ __metadata:
     datemath-parser: "npm:~1.0.6"
     debug: "npm:~4.4.1"
     geo-tz: "npm:~8.1.4"
-    ip-bigint: "npm:~8.2.1"
+    ip-bigint: "npm:~8.2.2"
     ip-cidr: "npm:~4.0.2"
     ip6addr: "npm:~0.2.5"
     ipaddr.js: "npm:~2.2.0"
@@ -1758,7 +1751,7 @@ __metadata:
     p-map: "npm:~7.0.3"
     shallow-clone: "npm:~3.0.1"
     validator: "npm:~13.12.0"
-  checksum: 10c0/a088410dce937c6a0239966e3f30c13ff29dc3cccefabbc42873926d724507a42f0c1b778893b8dbe165e9801b01bc4d3144d1fb471020050f16b352a2be4683
+  checksum: 10c0/a0dba5d6b60e68c06015b70fc9e3cba07689b2b401fc893a478e64c07ee59dc3576eb6420e8ea276abb6622e2816a13cf80fae5a8dab651db0b7ebc8876ce1ac
   languageName: node
   linkType: hard
 
@@ -2331,12 +2324,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.3.1":
-  version: 24.3.1
-  resolution: "@types/node@npm:24.3.1"
+"@types/node@npm:~24.4.0":
+  version: 24.4.0
+  resolution: "@types/node@npm:24.4.0"
   dependencies:
-    undici-types: "npm:~7.10.0"
-  checksum: 10c0/99b86fc32294fcd61136ca1f771026443a1e370e9f284f75e243b29299dd878e18c193deba1ce29a374932db4e30eb80826e1049b9aad02d36f5c30b94b6f928
+    undici-types: "npm:~7.11.0"
+  checksum: 10c0/3aefa4c6b006b3478f2d28a48d830ab7350ce24efdaf352011418e3ee17ed7683ca9c0a1840e770685ce78f413344badafa91e034be02488efe2eb6b612bd542
   languageName: node
   linkType: hard
 
@@ -2444,40 +2437,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.40.0, @typescript-eslint/eslint-plugin@npm:~8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.40.0"
+"@typescript-eslint/eslint-plugin@npm:8.43.0, @typescript-eslint/eslint-plugin@npm:~8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.43.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.40.0"
-    "@typescript-eslint/type-utils": "npm:8.40.0"
-    "@typescript-eslint/utils": "npm:8.40.0"
-    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/type-utils": "npm:8.43.0"
+    "@typescript-eslint/utils": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.40.0
+    "@typescript-eslint/parser": ^8.43.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/dc8889c3255bce6956432f099059179dd13826ba29670f81ba9238ecde46764ee63459eb73a7d88f4f30e1144a2f000d79c9e3f256fa759689d9b3b74d423bda
+  checksum: 10c0/9823f6e917d16f95a87fb1fd6c224f361a9f17386453ac97d7d457774cf2ea7bdbcfad37ad063b71ec01a4292127a8bfe69d1987b948e85def2410de8fe353dd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.40.0, @typescript-eslint/parser@npm:~8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/parser@npm:8.40.0"
+"@typescript-eslint/parser@npm:8.43.0, @typescript-eslint/parser@npm:~8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/parser@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.40.0"
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
-    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/43ca9589b8a1f3f4b30a214c0e2254fa0ad43458ef1258b1d62c5aad52710ad11b9315b124cda79163274147b82201a5d76fab7de413e34bfe8e377142b71e98
+  checksum: 10c0/b8296d3fac08f6e03c931843264a4219469a6a7d5c4d269fb14fe4c1547477a0dd1c259e6929c749efa043fb4e272436adfc94afdf07039d3b1d9e6956a6a0ea
   languageName: node
   linkType: hard
 
@@ -2494,16 +2487,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/project-service@npm:8.40.0"
+"@typescript-eslint/project-service@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/project-service@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.40.0"
-    "@typescript-eslint/types": "npm:^8.40.0"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.43.0"
+    "@typescript-eslint/types": "npm:^8.43.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/23d62e9ada9750136d0251f268bbe1f9784442ef258bb340a2e1e866749d8076730a14749d9a320d94d7c76df2d108caf21fe35e5dc100385f04be846dc979cb
+  checksum: 10c0/c9058b5fbf9642c35a303641e4ff2d0df1ddac337275bab84b56167f1019fbcb7e69959239fed82e53c747f58d6ee4c1859cf5b018803cba1b1aab430439d728
   languageName: node
   linkType: hard
 
@@ -2527,13 +2520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.40.0"
+"@typescript-eslint/scope-manager@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/visitor-keys": "npm:8.40.0"
-  checksum: 10c0/48af81f9cdcec466994d290561e8d2fa3f6b156a898b71dd0e65633c896543b44729c5353596e84de2ae61bfd20e1398c3309cdfe86714a9663fd5aded4c9cd0
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
+  checksum: 10c0/f87b3c3a5d3ad18326945288fa5b9b9fa662d87f466dc159e1514e00e359e830b80557f213acb3d23d5d600826b4cc4cfa5d2d479f8aba1b9834df19a640a779
   languageName: node
   linkType: hard
 
@@ -2546,37 +2539,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.40.0"
+"@typescript-eslint/tsconfig-utils@npm:8.43.0, @typescript-eslint/tsconfig-utils@npm:^8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.43.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/c2366dcd802901d5cd4f59fc4eab7a00ed119aa4591ba59c507fe495d9af4cfca19431a603602ea675e4c861962230d1c2f100896903750cd1fcfc134702a7d0
+  checksum: 10c0/b3a472368ad31e31e58ef019f6afec7387f5885e3fd423c71f3910b6d6b767324fde8bd60bec2e7505cc130317ece7fbc91314c44cdfea74ff76b5039bf26d52
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:^8.40.0":
-  version: 8.42.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.42.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/03882eeee279fafa2cb4ee3154742417fd29395b3bfe3f867d9d4cb9cb68d1200c885c35b96dd558a1aff8561ac3700cff8ca7680a5cf34e5e0e136a6ee3c30c
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/type-utils@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/type-utils@npm:8.40.0"
+"@typescript-eslint/type-utils@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/type-utils@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
-    "@typescript-eslint/utils": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+    "@typescript-eslint/utils": "npm:8.43.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/660b77d801b2538a4ccb65065269ad0e8370d0be985172b5ecb067f3eea22e64aa8af9e981b31bf2a34002339fe3253b09b55d181ce6d8242fc7daa80ac4aaca
+  checksum: 10c0/70e61233fd586c4545b0ee11871001ba603816fccb69b9fe883a653b32aa049e957a97f208f522b58480a4f4e1c6322b9a3ef60a389925eaefba94abcd44ff7e
   languageName: node
   linkType: hard
 
@@ -2594,24 +2578,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/types@npm:8.40.0"
-  checksum: 10c0/225374fff36d59288a5780667a7a1316c75090d5d60b70a8035ac18786120333ccd08dfdf0e05e30d5a82217e44c57b8708b769dd1eed89f12f2ac4d3a769f76
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:^8.38.0":
-  version: 8.39.0
-  resolution: "@typescript-eslint/types@npm:8.39.0"
-  checksum: 10c0/4240b01b218f3ef8a4f6343cb78cd531c12b2a134b6edd6ab67a9de4d1808790bc468f7579d5d38e507a206457d14a5e8970f6f74d29b9858633f77258f7e43b
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:^8.40.0":
-  version: 8.42.0
-  resolution: "@typescript-eslint/types@npm:8.42.0"
-  checksum: 10c0/d585dff5005328282cc59f9402e886a3db64727906ad3e68b49d7ef73bc07bef3ed569287ba826ebaa07b69be42a72232a38529951d64c28cebd83db0892cd33
+"@typescript-eslint/types@npm:8.43.0, @typescript-eslint/types@npm:^8.41.0, @typescript-eslint/types@npm:^8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/types@npm:8.43.0"
+  checksum: 10c0/60d19b695affce128fe1076ebe4cff7e05d38dd50155d653fc9e995eafa56c299fd49ad4d9d2997f118a75fb57e3ca18001623bc3ef3fa0111f863079203e4b2
   languageName: node
   linkType: hard
 
@@ -2654,14 +2624,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.40.0"
+"@typescript-eslint/typescript-estree@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.40.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.40.0"
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+    "@typescript-eslint/project-service": "npm:8.43.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/visitor-keys": "npm:8.43.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -2670,22 +2640,22 @@ __metadata:
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/6c1ffc17947cb36cbd987cf9705f85223ed1cce584b5244840e36a2b8480861f4dfdb0312f96afbc12e7d1ba586005f0d959042baa0a96a1913ac7ace8e8f6d4
+  checksum: 10c0/184ba925067d7fbcb377450195a89511f030a49d080e27058fa78078a069d86c1936b1a82ce6f19ff24c30c4de8b779deb050c36b06db5372c95fc7e5be7115a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/utils@npm:8.40.0"
+"@typescript-eslint/utils@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/utils@npm:8.43.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.40.0"
-    "@typescript-eslint/types": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
+    "@typescript-eslint/scope-manager": "npm:8.43.0"
+    "@typescript-eslint/types": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/6b3858b8725083fe7db7fb9bcbde930e758a6ba8ddedd1ed27d828fc1cbe04f54b774ef9144602f8eeaafeea9b19b4fd4c46fdad52a10ade99e6b282c7d0df92
+  checksum: 10c0/42fc8c60551361d80b5c53b303ba8cd20cf914665168416ad0a278cd44aae587311af9e4461f92ed28b5f36091d275a0e9974482d5e9ba95fc00108a537cdd36
   languageName: node
   linkType: hard
 
@@ -2741,13 +2711,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.40.0":
-  version: 8.40.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.40.0"
+"@typescript-eslint/visitor-keys@npm:8.43.0":
+  version: 8.43.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.43.0"
     eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10c0/592f1c8c2d3da43a7f74f8ead14f05fafc2e4609d5df36811cf92ead5dc94f6f669556a494048e4746cb3774c60bc52a8c83d75369d5e196778d935c70e7d3a1
+  checksum: 10c0/5d576eaf7bea41933ba726f4b24410bd3fc2521ef286967c3dc630c6a90fabff2a2d7c4d12cb841d3f946d2e5e6fb2605e7edd84e3360308fe379dbf2b8dc2fa
   languageName: node
   linkType: hard
 
@@ -5024,7 +4994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:~7.6.6":
+"eslint-plugin-testing-library@npm:~7.6.8":
   version: 7.6.8
   resolution: "eslint-plugin-testing-library@npm:7.6.8"
   dependencies:
@@ -5064,56 +5034,6 @@ __metadata:
   version: 4.2.1
   resolution: "eslint-visitor-keys@npm:4.2.1"
   checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.34.0":
-  version: 9.34.0
-  resolution: "eslint@npm:9.34.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.21.0"
-    "@eslint/config-helpers": "npm:^0.3.1"
-    "@eslint/core": "npm:^0.15.2"
-    "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.34.0"
-    "@eslint/plugin-kit": "npm:^0.3.5"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.4.0"
-    eslint-visitor-keys: "npm:^4.2.1"
-    espree: "npm:^10.4.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/ba3e54fa0c8ed23d062f91519afaae77fed922a6c4d76130b6cd32154bcb406aaea4b3c5ed88e0be40828c1d5b6921592f3947dbdc5e2043de6bd7aa341fe5ea
   languageName: node
   linkType: hard
 
@@ -6108,9 +6028,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:~14.4.7":
-  version: 14.4.7
-  resolution: "got@npm:14.4.7"
+"got@npm:~14.4.8":
+  version: 14.4.8
+  resolution: "got@npm:14.4.8"
   dependencies:
     "@sindresorhus/is": "npm:^7.0.1"
     "@szmarczak/http-timer": "npm:^5.0.1"
@@ -6123,7 +6043,7 @@ __metadata:
     p-cancelable: "npm:^4.0.1"
     responselike: "npm:^3.0.0"
     type-fest: "npm:^4.26.1"
-  checksum: 10c0/9b5b8dbc0642c78dbc64ab5ff6f12f6edab3e0cb80e89a3a69623a79ba3986f0ff0066a116fba47c0aacce4b0ba1eccf72f923f7fac13a31ce852bf9e2cb8f81
+  checksum: 10c0/7e8eb24dde86179e1163dc8c7cdac65b59764274f952fe3407252324a06912f77ebedf81cc17173120196558490d3f27525e0223ded5651c1937d25eb263867e
   languageName: node
   linkType: hard
 
@@ -6404,10 +6324,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:~4.1.0":
-  version: 4.1.0
-  resolution: "import-meta-resolve@npm:4.1.0"
-  checksum: 10c0/42f3284b0460635ddf105c4ad99c6716099c3ce76702602290ad5cbbcd295700cbc04e4bdf47bacf9e3f1a4cec2e1ff887dabc20458bef398f9de22ddff45ef5
+"import-meta-resolve@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: 10c0/3ee8aeecb61d19b49d2703987f977e9d1c7d4ba47db615a570eaa02fe414f40dfa63f7b953e842cbe8470d26df6371332bfcf21b2fd92b0112f9fea80dde2c4c
   languageName: node
   linkType: hard
 
@@ -6484,10 +6404,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-bigint@npm:~8.2.1":
-  version: 8.2.1
-  resolution: "ip-bigint@npm:8.2.1"
-  checksum: 10c0/5d19596b3374beade4daa278f9a35b7d1fc81c9fa4bf5ba8cc39dc3d198363b9ca6930025a70b3b37a46c5c514a87f2337c4ba2efeb0e514a5d233d7fe15495b
+"ip-bigint@npm:~8.2.2":
+  version: 8.2.2
+  resolution: "ip-bigint@npm:8.2.2"
+  checksum: 10c0/0be02e349c4a694e5bf64f3f5530d2cc159b59da14ca4a895cef1668334256c60bd0c3f219e06b1f49f6962de88e7ce7ba3610004d973dafb73779a9beea4464
   languageName: node
   linkType: hard
 
@@ -10183,15 +10103,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "standard-assets-bundle@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:~1.1.24"
-    "@terascope/job-components": "npm:~1.12.2"
-    "@terascope/scripts": "npm:~1.21.5"
+    "@terascope/eslint-config": "npm:~1.1.25"
+    "@terascope/job-components": "npm:~1.12.3"
+    "@terascope/scripts": "npm:~1.21.6"
     "@terascope/standard-asset-apis": "npm:~1.1.1"
     "@types/express": "npm:~5.0.3"
     "@types/fs-extra": "npm:~11.0.4"
     "@types/jest": "npm:~30.0.0"
     "@types/json2csv": "npm:~5.0.7"
-    "@types/node": "npm:~24.3.1"
+    "@types/node": "npm:~24.4.0"
     "@types/node-gzip": "npm:~1.1.3"
     "@types/semver": "npm:~7.7.1"
     "@types/timsort": "npm:~0.3.3"
@@ -10201,7 +10121,7 @@ __metadata:
     jest-extended: "npm:~6.0.0"
     node-notifier: "npm:~10.0.1"
     semver: "npm:~7.7.2"
-    teraslice-test-harness: "npm:~1.3.7"
+    teraslice-test-harness: "npm:~1.3.8"
     ts-jest: "npm:~29.4.1"
     tslib: "npm:~2.8.1"
     typescript: "npm:~5.9.2"
@@ -10213,12 +10133,12 @@ __metadata:
   resolution: "standard@workspace:asset"
   dependencies:
     "@faker-js/faker": "npm:~10.0.0"
-    "@terascope/data-mate": "npm:~1.12.0"
-    "@terascope/job-components": "npm:~1.12.2"
+    "@terascope/data-mate": "npm:~1.12.1"
+    "@terascope/job-components": "npm:~1.12.3"
     "@terascope/standard-asset-apis": "npm:~1.1.1"
-    "@terascope/teraslice-state-storage": "npm:~1.12.2"
+    "@terascope/teraslice-state-storage": "npm:~1.13.0"
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     "@types/chance": "npm:~1.1.7"
     "@types/express": "npm:~5.0.3"
     "@types/ms": "npm:^0.7.34"
@@ -10230,7 +10150,7 @@ __metadata:
     randexp: "npm:~0.5.3"
     short-unique-id: "npm:~5.3.2"
     timsort: "npm:~0.3.0"
-    ts-transforms: "npm:~1.12.0"
+    ts-transforms: "npm:~1.12.1"
     tslib: "npm:~2.8.1"
   languageName: unknown
   linkType: soft
@@ -10631,15 +10551,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teraslice-test-harness@npm:~1.3.7":
-  version: 1.3.7
-  resolution: "teraslice-test-harness@npm:1.3.7"
+"teraslice-test-harness@npm:~1.3.8":
+  version: 1.3.8
+  resolution: "teraslice-test-harness@npm:1.3.8"
   dependencies:
     "@terascope/fetch-github-release": "npm:~2.2.1"
-    "@terascope/job-components": "npm:~1.12.2"
+    "@terascope/job-components": "npm:~1.12.3"
     decompress: "npm:~4.2.1"
     fs-extra: "npm:~11.3.1"
-  checksum: 10c0/c1a88efddc4fb6c4b9817078a7389d4f809b3b95e9bb34fbcda093dcda622c6ab95cbbb6ce0085a9b0dccbc82352742c7c84c649f9b546122fb32522461d33d1
+  checksum: 10c0/b2ab469949d442314b624be12c4de28db2ca33686ad83ea16608ddfc70496da3d8e96fe51a1b2df19c79bd49a1a230b960bac41620b2e1e6085279ab235bec06
   languageName: node
   linkType: hard
 
@@ -10844,13 +10764,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-transforms@npm:~1.12.0":
-  version: 1.12.0
-  resolution: "ts-transforms@npm:1.12.0"
+"ts-transforms@npm:~1.12.1":
+  version: 1.12.1
+  resolution: "ts-transforms@npm:1.12.1"
   dependencies:
-    "@terascope/data-mate": "npm:~1.12.0"
+    "@terascope/data-mate": "npm:~1.12.1"
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     awesome-phonenumber: "npm:~7.5.0"
     graphlib: "npm:~2.1.8"
     jexl: "npm:~2.3.0"
@@ -10861,7 +10781,7 @@ __metadata:
   bin:
     ts-match: ./bin/ts-transform.js
     ts-transform: ./bin/ts-transform.js
-  checksum: 10c0/884cbb7965f525f2486deacb6d660ba93991885cac2d3e0eb0b2e2ad4c5d170bd412915a984c3f516917f13a56dc5f15b6d4297a53688b33a3f050ee61f57bfd
+  checksum: 10c0/924d036a301020bcb2d77ba0495d046cb70c2de0dae72db7f77da24ed06780bf023c909b6d58e6bbb8e9234ce3f34d3a7f77b28f2ad3eeb23fbd5387c6167d04
   languageName: node
   linkType: hard
 
@@ -11055,9 +10975,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.28.11":
-  version: 0.28.12
-  resolution: "typedoc@npm:0.28.12"
+"typedoc@npm:~0.28.12":
+  version: 0.28.13
+  resolution: "typedoc@npm:0.28.13"
   dependencies:
     "@gerrit0/mini-shiki": "npm:^3.12.0"
     lunr: "npm:^2.3.9"
@@ -11068,22 +10988,22 @@ __metadata:
     typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/b83a182df0887dce0a27df462e86e9ad771b3eff32eeef07b2b2424e57794050de540cd4667a640165518360fe47393cc92b55bc4ca861bd5746ed696df086d0
+  checksum: 10c0/f4815cb21a62fadbfeb6f5ad6405d3c819b6bcb20bd1e125c5b1a1a7c7bfabbd9dd67d742f767ce95283e99814a361b86bcc632e9ffa595e51e057778def4d57
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.40.0":
-  version: 8.40.0
-  resolution: "typescript-eslint@npm:8.40.0"
+"typescript-eslint@npm:~8.43.0":
+  version: 8.43.0
+  resolution: "typescript-eslint@npm:8.43.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.40.0"
-    "@typescript-eslint/parser": "npm:8.40.0"
-    "@typescript-eslint/typescript-estree": "npm:8.40.0"
-    "@typescript-eslint/utils": "npm:8.40.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.43.0"
+    "@typescript-eslint/parser": "npm:8.43.0"
+    "@typescript-eslint/typescript-estree": "npm:8.43.0"
+    "@typescript-eslint/utils": "npm:8.43.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/b9bf9cbe13a89348ae2a13a7839238b1b058c1e188d9cc1028810c43f1b48cf256f5255ca94c38acf3cd5a405c918ad96d5b7f7a6ad3f82fa7429122a7883a83
+  checksum: 10c0/ee8429b16a5b7678136b8b2688bec03d11b5f1590895523ba9b8c6920c7a0876c9bf3bf0ff415df79e57c10ed48955cf183b727394b1c228ca75b5168fb466a1
   languageName: node
   linkType: hard
 
@@ -11171,10 +11091,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.10.0":
-  version: 7.10.0
-  resolution: "undici-types@npm:7.10.0"
-  checksum: 10c0/8b00ce50e235fe3cc601307f148b5e8fb427092ee3b23e8118ec0a5d7f68eca8cee468c8fc9f15cbb2cf2a3797945ebceb1cbd9732306a1d00e0a9b6afa0f635
+"undici-types@npm:~7.11.0":
+  version: 7.11.0
+  resolution: "undici-types@npm:7.11.0"
+  checksum: 10c0/24ff69baeaebc7d09f4dae68564df850b4ff561810148ff6c37d3fc64dd1460c55e59e604420495e73b1fb48594a1c98e69f6732086a24e01b88f2d926378af1
   languageName: node
   linkType: hard
 
@@ -11344,12 +11264,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:~11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:~12.0.0":
+  version: 12.0.0
+  resolution: "uuid@npm:12.0.0"
   bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+    uuid: dist/bin/uuid
+  checksum: 10c0/242db6735d15a187a0d7f22576db02668f974ffc65d0806b23fe4237cbb0db3153442cb3082c7550784acb6272e5c6c931532916f9604bd814dfab1edf2dac40
   languageName: node
   linkType: hard
 
@@ -11624,15 +11544,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlucene-parser@npm:~1.10.2":
-  version: 1.10.2
-  resolution: "xlucene-parser@npm:1.10.2"
+"xlucene-parser@npm:~1.10.3":
+  version: 1.10.3
+  resolution: "xlucene-parser@npm:1.10.3"
   dependencies:
     "@terascope/types": "npm:~1.4.4"
-    "@terascope/utils": "npm:~1.10.2"
+    "@terascope/utils": "npm:~1.10.3"
     peggy: "npm:~4.2.0"
     ts-pegjs: "npm:~4.2.1"
-  checksum: 10c0/66776586e182206937a909aeefea77eeca4fd70e1d57a78c337f35c2e299bc3fe225f0a22abf8034e6254d015ddbe0eaae9e5df9c7988add471cf8489aa76eb2
+  checksum: 10c0/1b4523246ccaa4a756f7aa27148312524da30a4f6a7beaa86e76c402fef5cd60537c61c10a3ee1321d294bf30ebc0618c21792e7633bc7e063a18a1d8122c904
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following packages:
# standard
  - dependencies
    - @terascope/data-mate from 1.12.0 to 1.12.1
    - @terascope/job-components from 1.12.2 to 1.12.3
    - @terascope/teraslice-state-storage from 1.12.2 to 1.13.0
    - @terascope/utils from 1.10.2 to 1.10.3
    - ts-transforms from 1.12.0 to 1.12.1
# standard-assets-bundle
  - devDependencies
    - @terascope/eslint-config from 1.1.24 to 1.1.25
    - @terascope/job-components from 1.12.2 to 1.12.3
    - @terascope/scripts from 1.21.5 to 1.21.6
    - @types/node from 24.3.1 to 24.4.0
    - teraslice-test-harness from 1.3.7 to 1.3.8
# @terascope/standard-asset-apis
  - dependencies
    - @terascope/utils from 1.10.2 to 1.10.3
  - devDependencies
    - @terascope/scripts from 1.21.5 to 1.21.6
    - @types/node from 24.3.1 to 24.4.0