### PR TITLE
[sample_exact_es_percent] Improve logging

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "3.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/src/sample_exact_es_percent/processor.ts
+++ b/asset/src/sample_exact_es_percent/processor.ts
@@ -88,7 +88,10 @@ export default class SampleExactESPercent extends BatchProcessor<SampleExactESPe
                     throw new Error(`Percent must be a number between 0 and 100, received ${percent}.`);
                 }
 
-                this.logger.info('New sample percent: ', percent);
+                if (this.percentage !== (percent / 100)) {
+                    this.logger.info('New sample percent: ', percent);
+                }
+
                 return percent / 100;
             });
         } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",


### PR DESCRIPTION
This PR updates the `sample_exact_es_percent` processor to only log the new percent if it has changed from the percent calculated in the previous window.

ref: #1216 