### PR TITLE
data_generator - get size from sender api, not op

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "3.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/src/data_generator/counter.ts
+++ b/asset/src/data_generator/counter.ts
@@ -7,7 +7,7 @@ export default class Counter {
     size: number;
     handle: () => Promise<CounterResults>;
 
-    constructor(isPersistent: boolean, size: number, sliceSize = 5000, startingCount = 0) {
+    constructor(isPersistent: boolean, size: number, sliceSize: number, startingCount = 0) {
         this.numOfRecordsProcessed = startingCount;
         this.sliceSize = sliceSize;
         this.size = size;

--- a/asset/src/data_generator/schema.ts
+++ b/asset/src/data_generator/schema.ts
@@ -36,8 +36,9 @@ export default class Schema extends BaseSchema<DataGenerator> {
                 format: 'optional_string'
             },
             size: {
-                doc: 'The limit to the number of docs pulled in a chunk, if the number of docs retrieved '
-                    + 'by the interval exceeds this number, it will cause the function to recurse to provide a smaller batch',
+                doc: 'If job `lifecycle` is set to `once`, then size is the total number of generated documents. '
+                    + 'If job `lifecycle` is set to `persistent`, if the sender operation/api does not specify a size '
+                    + 'then the generator will constantly stream data in chunks equal to the size.',
                 default: 5000,
                 format(val: any) {
                     if (isNaN(val)) {

--- a/asset/src/data_generator/schema.ts
+++ b/asset/src/data_generator/schema.ts
@@ -37,8 +37,8 @@ export default class Schema extends BaseSchema<DataGenerator> {
             },
             size: {
                 doc: 'If job `lifecycle` is set to `once`, then size is the total number of generated documents. '
-                    + 'If job `lifecycle` is set to `persistent`, if the sender operation/api does not specify a size '
-                    + 'then the generator will constantly stream data in chunks equal to the size.',
+                    + 'If job `lifecycle` is set to `persistent` and if the sender operation and api do not specify '
+                    + 'a size, then the generator will constantly stream data in chunks equal to the size.',
                 default: 5000,
                 format(val: any) {
                     if (isNaN(val)) {

--- a/asset/src/data_generator/slicer.ts
+++ b/asset/src/data_generator/slicer.ts
@@ -1,4 +1,4 @@
-import { get } from '@terascope/core-utils';
+import { get, isKey } from '@terascope/core-utils';
 import { Slicer, SlicerRecoveryData } from '@terascope/job-components';
 import { DataGenerator, CounterResults } from './interfaces.js';
 import Counter from './counter.js';
@@ -10,17 +10,25 @@ export default class DataGeneratorSlicer extends Slicer<DataGenerator> {
         await super.initialize(recoveryData);
 
         const { size } = this.opConfig;
-        const isPersistent = this.executionConfig.lifecycle === 'persistent';
+        const { lifecycle, operations, apis } = this.executionConfig;
+        const isPersistent = lifecycle === 'persistent';
         let alreadyProcessed: undefined | number;
 
         if (this.recoveryData) {
             alreadyProcessed = get(this.recoveryData[0], 'lastSlice.processed', 0);
         }
 
-        const opListSize = this.executionConfig.operations.length - 1;
-        const lastOp = this.executionConfig.operations[opListSize];
+        let lastOpSize;
+        const opListSize = operations.length - 1;
+        const lastOpApiName = operations[opListSize]._api_name;
+        if (lastOpApiName !== undefined) {
+            const lastOpApi = apis.filter((api) => api._name = lastOpApiName)[0];
+            if (isKey(lastOpApi, 'size')) {
+                lastOpSize = lastOpApi.size;
+            }
+        }
 
-        const counter = new Counter(isPersistent, size, lastOp.size, alreadyProcessed);
+        const counter = new Counter(isPersistent, size, lastOpSize, alreadyProcessed);
         this.countHandle = counter.handle;
     }
 

--- a/asset/src/data_generator/slicer.ts
+++ b/asset/src/data_generator/slicer.ts
@@ -1,4 +1,4 @@
-import { get, isKey } from '@terascope/core-utils';
+import { get } from '@terascope/core-utils';
 import { Slicer, SlicerRecoveryData } from '@terascope/job-components';
 import { DataGenerator, CounterResults } from './interfaces.js';
 import Counter from './counter.js';
@@ -18,17 +18,25 @@ export default class DataGeneratorSlicer extends Slicer<DataGenerator> {
             alreadyProcessed = get(this.recoveryData[0], 'lastSlice.processed', 0);
         }
 
-        let lastOpSize;
+        let sliceSize: undefined | number = undefined;
         const opListSize = operations.length - 1;
-        const lastOpApiName = operations[opListSize]._api_name;
-        if (lastOpApiName !== undefined) {
-            const lastOpApi = apis.filter((api) => api._name = lastOpApiName)[0];
-            if (isKey(lastOpApi, 'size')) {
-                lastOpSize = lastOpApi.size;
+        const lastOp = operations[opListSize];
+
+        if (lastOp.size) {
+            sliceSize = lastOp.size;
+        } else {
+            const lastOpApiName = lastOp._api_name;
+            if (lastOpApiName) {
+                const lastOpApi = apis.find((api) => api._name = lastOpApiName);
+                sliceSize = lastOpApi?.size;
             }
         }
 
-        const counter = new Counter(isPersistent, size, lastOpSize, alreadyProcessed);
+        if (!sliceSize) {
+            sliceSize = size;
+        }
+
+        const counter = new Counter(isPersistent, size, sliceSize, alreadyProcessed);
         this.countHandle = counter.handle;
     }
 

--- a/docs/asset/operations/data_generator.md
+++ b/docs/asset/operations/data_generator.md
@@ -32,11 +32,11 @@ Example of jobs using the `data_generator` processor
 Output of the example job
 
 ```javascript
-const slice = { count: 1000 }
+const slice = { count: 10000 }
 
 const results = await fetcher.run(slice);
 
-results.length ==== 1000;
+results.length ==== 10000;
 
 results[0] === {
     "ip": "1.12.146.136",
@@ -114,7 +114,7 @@ results[0] === {
 
 ### Stress Test and persistent mode
 
-Example of a job using the `data_generator` to generate a persistent slice of 10,000 records for all 50 workers until the job is shutdown. This is useful for stress testing systems and down stream processes.
+Example of a job using the `data_generator` to generate a persistent slice of 10,000 records for all 50 workers until the job is shutdown. This is useful for stress testing systems and down stream processes. **NOTE:** If the the job has a sender operation/API configuration with a size field it will override the `size` field on the `data_generator`.
 
 ```json
 {
@@ -141,11 +141,11 @@ Example of a job using the `data_generator` to generate a persistent slice of 10
 Example output from the above job:
 
 ```javascript
-const slice = { count: 1000 }
+const slice = { count: 10000 }
 
 const results = await fetcher.run(slice);
 
-results.length ==== 1000;
+results.length ==== 10000;
 
 results[0] === {
     "ip": "1.12.146.136",
@@ -161,7 +161,7 @@ results[0] === {
 
 ### Generate controlled stream of data over a period of time
 
-Example of a job using the `data_generator` processor to generate approximately 10,000 records per minute or 60,000 records per hour. Results could very as this is a loose approximation.
+Example of a job using the `data_generator` processor to generate approximately 10,000 records per minute or 60,000 records per hour. Results could vary as this is a loose approximation. **NOTE:** If the the job has a sender operation/API configuration with a size field it will override the `size` field on the `data_generator`.
 
 ```json
 {
@@ -189,7 +189,7 @@ Example of a job using the `data_generator` processor to generate approximately 
 | Configuration | Description | Type | Notes |
 | ------------- | ------------| -----| ------|
 | _op           | Name of operation, it must reflect the exact name of the file | String  | required |
-| size          | If job `lifecycle` is set to `once`, then size is the total number of generated documents. If job `lifecycle` is set to `persistent`, then the generator will constantly stream data in chunks equal to the size | Number | required |
+| size          | If job `lifecycle` is set to `once`, then size is the total number of generated documents. If job `lifecycle` is set to `persistent`, if the sender operation/api does not specify a size then the generator will constantly stream data in chunks equal to the size. | Number | required |
 | json_schema   | File path to custom schema | String  | optional, the schema must be exported Node style `module.exports = schema` |
 | format        | Format of date in the timestamp field, options are `dateNow`, `utcDate`, `utcBetween`, `isoBetween`.  See advanced configuration section for more details | String  | optional, defaults to `dateNow` |
 | start         | Start of date range | String  | optional, only used with format `isoBetween` or `utcBetween`, defaults to Thu Jan 01 1970 00:00:00 GMT-0700 (MST) |

--- a/docs/asset/operations/data_generator.md
+++ b/docs/asset/operations/data_generator.md
@@ -114,7 +114,7 @@ results[0] === {
 
 ### Stress Test and persistent mode
 
-Example of a job using the `data_generator` to generate a persistent slice of 10,000 records for all 50 workers until the job is shutdown. This is useful for stress testing systems and down stream processes. **NOTE:** If the the job has a sender operation/API configuration with a size field it will override the `size` field on the `data_generator`.
+Example of a job using the `data_generator` to generate a persistent slice of 10,000 records for all 50 workers until the job is shutdown. This is useful for stress testing systems and down stream processes. **NOTE:** If the job has a sender operation or API configuration with a size field it will override the `size` field on the `data_generator`.
 
 ```json
 {
@@ -161,7 +161,7 @@ results[0] === {
 
 ### Generate controlled stream of data over a period of time
 
-Example of a job using the `data_generator` processor to generate approximately 10,000 records per minute or 60,000 records per hour. Results could vary as this is a loose approximation. **NOTE:** If the the job has a sender operation/API configuration with a size field it will override the `size` field on the `data_generator`.
+Example of a job using the `data_generator` processor to generate approximately 10,000 records per minute or 60,000 records per hour. Results could vary as this is a loose approximation. **NOTE:** If  the job has a sender operation or API configuration with a size field it will override the `size` field on the `data_generator`.
 
 ```json
 {
@@ -189,7 +189,7 @@ Example of a job using the `data_generator` processor to generate approximately 
 | Configuration | Description | Type | Notes |
 | ------------- | ------------| -----| ------|
 | _op           | Name of operation, it must reflect the exact name of the file | String  | required |
-| size          | If job `lifecycle` is set to `once`, then size is the total number of generated documents. If job `lifecycle` is set to `persistent`, if the sender operation/api does not specify a size then the generator will constantly stream data in chunks equal to the size. | Number | required |
+| size          | If job `lifecycle` is set to `once`, then size is the total number of generated documents. If job `lifecycle` is set to `persistent` and if the sender operation and api do not specify a size, then the generator will constantly stream data in chunks equal to the size. | Number | required |
 | json_schema   | File path to custom schema | String  | optional, the schema must be exported Node style `module.exports = schema` |
 | format        | Format of date in the timestamp field, options are `dateNow`, `utcDate`, `utcBetween`, `isoBetween`.  See advanced configuration section for more details | String  | optional, defaults to `dateNow` |
 | start         | Start of date range | String  | optional, only used with format `isoBetween` or `utcBetween`, defaults to Thu Jan 01 1970 00:00:00 GMT-0700 (MST) |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",

--- a/test/data-generator/slicer-spec.ts
+++ b/test/data-generator/slicer-spec.ts
@@ -1,12 +1,21 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { SlicerRecoveryData, LifeCycle } from '@terascope/job-components';
 import { SlicerTestHarness, newTestJobConfig } from 'teraslice-test-harness';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const testAssetPath = path.join(dirname, '../fixtures/someAssetId');
+const opPathName = path.join(dirname, '../../asset/');
+const assetDir = [testAssetPath, opPathName];
 
 interface SlicerTestArgs {
     opConfig: any;
     numOfSlicers?: number;
     recoveryData?: SlicerRecoveryData[];
     lifecycle?: LifeCycle;
-    size: number;
+    size?: number;
+    apis?: any[];
+    apiName?: string;
 }
 
 describe('data_generator slicer', () => {
@@ -22,7 +31,9 @@ describe('data_generator slicer', () => {
         numOfSlicers = 1,
         recoveryData,
         lifecycle = 'once',
-        size
+        size,
+        apis,
+        apiName
     }: SlicerTestArgs) {
         const job = newTestJobConfig({
             analytics: true,
@@ -30,13 +41,11 @@ describe('data_generator slicer', () => {
             lifecycle,
             operations: [
                 opConfig,
-                {
-                    _op: 'noop',
-                    size
-                }
+                { _op: 'noop', size, ...(apiName && { _api_name: apiName }) }
             ],
+            ...(apis && { apis }),
         });
-        harness = new SlicerTestHarness(job, { clients });
+        harness = new SlicerTestHarness(job, { clients, assetDir });
         await harness.initialize(recoveryData);
         return harness;
     }
@@ -145,6 +154,72 @@ describe('data_generator slicer', () => {
         expect(results1).toEqual([{ count: 5000, processed: 5000 }]);
         expect(results2).toEqual([{ count: 5000, processed: 10000 }]);
         expect(results3).toEqual([{ count: 5000, processed: 15000 }]);
+    });
+
+    it('slicer in "persistent" mode will prioritize lastOp.size over lastOpApis.size', async () => {
+        const opConfig = { _op: 'data_generator', size: 550 };
+        const apiName = 'test_api';
+        const apiSize = 10000;
+        const opSize = 5000;
+
+        const config: SlicerTestArgs = {
+            lifecycle: 'persistent',
+            numOfSlicers: 1,
+            opConfig,
+            size: opSize,
+            apis: [{ _name: apiName, size: apiSize }],
+            apiName
+        };
+        const testHarness = await makeSlicerTest(config);
+
+        const results1 = await testHarness.createSlices();
+        const results2 = await testHarness.createSlices();
+        const results3 = await testHarness.createSlices();
+
+        expect(results1).toEqual([{ count: 5000, processed: 5000 }]);
+        expect(results2).toEqual([{ count: 5000, processed: 10000 }]);
+        expect(results3).toEqual([{ count: 5000, processed: 15000 }]);
+    });
+
+    it('slicer in "persistent" mode will prioritize lastOpApis.size over opConfig.size', async () => {
+        const opConfig = { _op: 'data_generator', size: 550 };
+        const apiName = 'test_api';
+        const apiSize = 1000;
+
+        const config: SlicerTestArgs = {
+            lifecycle: 'persistent',
+            numOfSlicers: 1,
+            opConfig,
+            apis: [{ _name: apiName, size: apiSize }],
+            apiName
+        };
+        const testHarness = await makeSlicerTest(config);
+
+        const results1 = await testHarness.createSlices();
+        const results2 = await testHarness.createSlices();
+        const results3 = await testHarness.createSlices();
+
+        expect(results1).toEqual([{ count: 1000, processed: 1000 }]);
+        expect(results2).toEqual([{ count: 1000, processed: 2000 }]);
+        expect(results3).toEqual([{ count: 1000, processed: 3000 }]);
+    });
+
+    it('slicer in "persistent" mode will produce opConfig.size records per slice if lastOp and lastOpApi have no size', async () => {
+        const opConfig = { _op: 'data_generator', size: 550 };
+        const config: SlicerTestArgs = {
+            lifecycle: 'persistent',
+            numOfSlicers: 1,
+            opConfig
+        };
+        const testHarness = await makeSlicerTest(config);
+
+        const results1 = await testHarness.createSlices();
+        const results2 = await testHarness.createSlices();
+        const results3 = await testHarness.createSlices();
+
+        expect(results1).toEqual([{ count: 550, processed: 550 }]);
+        expect(results2).toEqual([{ count: 550, processed: 1100 }]);
+        expect(results3).toEqual([{ count: 550, processed: 1650 }]);
     });
 
     it('data generator will only return one slicer', async () => {

--- a/test/data-generator/slicer-spec.ts
+++ b/test/data-generator/slicer-spec.ts
@@ -41,7 +41,11 @@ describe('data_generator slicer', () => {
             lifecycle,
             operations: [
                 opConfig,
-                { _op: 'noop', size, ...(apiName && { _api_name: apiName }) }
+                {
+                    _op: 'noop',
+                    size,
+                    ...(apiName && { _api_name: apiName })
+                }
             ],
             ...(apis && { apis }),
         });


### PR DESCRIPTION
The `data_generator` looks for the `size` field on the sender operation to determine how many records to create per slice, otherwise it defaults to 5000. There are 2 issues with this:
- In teraslice v3 compatible assets the `size` field has been moved from the operation to the API for the senders that have a size (elasticsearch_bulk, kafka_sender), so the default was being used.
- all the docs say that if the sender doesn't specify a size we should use the `size` set by `data_generator`. This was the expectation that many of the developers had, and we think it should do this.

This PR fixes the logic to look at the sender operation's size, then the sender API's size, and then use the `data_generator`'s size, which will use the schema default of 5000 if not set by the job.

ref: #1208