### PR TITLE
[CI] pin reusable workflows to latest main commit hash

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   call-master-asset-build:
     if: github.event.pull_request.merged == true && github.base_ref == 'master'
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit
 
   call-prerelease-asset-build:
     if: github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/standard-assets-v')
-    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/prerelease-asset-build-and-publish.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   check-docker-limit-before:
-   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@main
+   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
    secrets: inherit
 
   cache-docker-images:
     needs: check-docker-limit-before
-    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@main
+    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit
 
   build-standard-assets:
@@ -271,7 +271,7 @@ jobs:
   check-docker-limit-after:
     needs: test-standard-assets
     if: always()
-    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@main
+    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit
 
   all-tests-passed:

--- a/.github/workflows/test-prerelease-asset.yml
+++ b/.github/workflows/test-prerelease-asset.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   call-asset-test-workflow:
-    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@main
+    uses: terascope/workflows/.github/workflows/prerelease-asset-test.yml@92c8f6b6312803300b0f36ba6b38d8007d7f471f
     secrets: inherit


### PR DESCRIPTION
This PR pins reusable workflows to the latest commit hash for the main @terascope/workflows branch instead of the branch name. This will allow us to update reusable workflow security without breaking current workflows.