### PR TITLE
Bump asset to v2.2.5

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "3.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",


### PR DESCRIPTION
This PR makes the following changes:
- bump: (patch) standard@2.2.5, standard-assets-bundle@2.2.5. #1241 made a small change to the `drop_field_conditional` schema that should get released.