### PR TITLE
Date router dead letter default

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,6 +1,6 @@
 {
     "name": "standard",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "Teraslice standard processor asset bundle",
     "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard",
     "displayName": "Asset",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "repository": {

--- a/asset/src/date_router/schema.ts
+++ b/asset/src/date_router/schema.ts
@@ -39,10 +39,10 @@ export default class Schema extends BaseSchema<DateRouterConfig> {
                     'This action will specify what to do when failing to parse or transform a record.',
                     'The following builtin actions are supported:',
                     '  - "throw": throw the original error​​',
-                    '  - "log": log the error and the data​​',
-                    '  - "none": (default) skip the error entirely',
-                    'If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name.',
-                    'The API must be already be created by a operation before it can used.'
+                    '  - "log": (default) log the error and the data​​',
+                    '  - "none": skip the error entirely',
+                    'If none of the actions are specified it will try to use a registered Dead Letter Queue API under that name.',
+                    'The API must already be created by an operation before it can be used.'
                 ].join('\n'),
                 default: 'log',
                 format: 'optional_string'

--- a/asset/src/date_router/schema.ts
+++ b/asset/src/date_router/schema.ts
@@ -33,6 +33,19 @@ export default class Schema extends BaseSchema<DateRouterConfig> {
                 doc: 'determines if the date unit (year, month, day) should be included in final output',
                 default: false,
                 format: 'Boolean'
+            },
+            _dead_letter_action: {
+                doc: [
+                    'This action will specify what to do when failing to parse or transform a record.',
+                    'The following builtin actions are supported:',
+                    '  - "throw": throw the original error​​',
+                    '  - "log": log the error and the data​​',
+                    '  - "none": (default) skip the error entirely',
+                    'If none of the actions are specified it will try and use a registered Dead Letter Queue API under that name.',
+                    'The API must be already be created by a operation before it can used.'
+                ].join('\n'),
+                default: 'log',
+                format: 'optional_string'
             }
         };
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "standard-assets-bundle",
     "displayName": "Standard Assets Bundle",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "private": true,
     "description": "Teraslice standard processor asset bundle",
     "homepage": "https://github.com/terascope/standard-assets",


### PR DESCRIPTION
This PR makes the following change:
- The schema for the `DateRouterProcessor` operation now includes the `_dead_letter_action` field with a default value of `log`. This will override the default value of `throw` that is set by the `opSchema` in job-components when the schemas are merged during opConfig validation.

The `DateRouterProcessor` tries to validate the date before it is used to create the route metadata. If validation fails the function will throw. Because the processor is a `MapProcessor`, when set to `throw` the whole map function will fail, the slice will error and and no records from the slice will be processed. When set to `log` the error is caught, an error level log is printed showing the `Bad record` and the map function continues with the rest of the records for that slice. The bad record is replaced with `null`, which will cause an error on the `RoutedSender` (no metadata to parse), so that processor must also set the `_dead_letter_action` to not `throw` or we run into a similar problem. 

Ref: #1246