### PR TITLE
[CI] pass github token to e2e test step

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   call-asset-build:
     if: github.event.pull_request.merged == true
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@ee93e5655fd79976999f2c665ac1b6d7e334ec3b
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@b7b03054122f0f4c73a15f523bb224588552f55c
     with:
       teraslice-cli-version: ${{ startsWith(github.base_ref, 'release/standard-assets-v') && 'prerelease' || 'latest' }}
     permissions:

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@ee93e5655fd79976999f2c665ac1b6d7e334ec3b
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@b7b03054122f0f4c73a15f523bb224588552f55c
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -300,7 +300,10 @@ jobs:
           TERASLICE_CLI_VERSION: ${{ needs.compute-vars.outputs.TERASLICE_CLI_VERSION }}
         run: npm install -g "teraslice-cli@$TERASLICE_CLI_VERSION"
 
-      - run: pnpm test:e2e
+      - name: Test e2e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm test:e2e
       
       - name: Upload logs artifact
         if: failure()

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo "TERASLICE_CLI_VERSION=$TERASLICE_CLI_VERSION" >> $GITHUB_OUTPUT
         
   check-docker-limit-before:
-    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@ee93e5655fd79976999f2c665ac1b6d7e334ec3b
+    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@b7b03054122f0f4c73a15f523bb224588552f55c
     permissions:
       contents: read
     secrets:
@@ -48,7 +48,7 @@ jobs:
 
   cache-docker-images:
     needs: check-docker-limit-before
-    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@ee93e5655fd79976999f2c665ac1b6d7e334ec3b
+    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@b7b03054122f0f4c73a15f523bb224588552f55c
     permissions:
       contents: read
     secrets:
@@ -371,7 +371,7 @@ jobs:
   check-docker-limit-after:
     needs: [test-standard-assets, test-standard-assets-encrypted, test-e2e]
     if: always()
-    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@ee93e5655fd79976999f2c665ac1b6d7e334ec3b
+    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@b7b03054122f0f4c73a15f523bb224588552f55c
     permissions:
       contents: read
     secrets:


### PR DESCRIPTION
This PR makes the following changes:
- updates the `test-asset` workflow to pass `GITHUB_TOKEN` as an env variable during the e2e tests. This authenticates API calls to github and prevents a possible rate limit error when several jobs hit the github API at once.
- update @terascope/workflows reusable workflow hashes

Ref: https://github.com/terascope/teraslice/issues/4475