### PR TITLE
[CI] pass github token to workflow jobs that download other assets

### DIFF
--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -111,6 +111,7 @@ jobs:
       contents: read
     env:
       NODE_OPTIONS: "--max-old-space-size=4096"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
        # opensearch is finiky, keep testing others if it fails
       fail-fast: false
@@ -250,6 +251,7 @@ jobs:
       contents: read
     env:
       NODE_OPTIONS: "--max-old-space-size=4096"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
        # opensearch is finiky, keep testing others if it fails
       fail-fast: false


### PR DESCRIPTION
Pass github token to `test.yml` jobs that require another asset. The token is passed to `fetch-github-release` and prevents a rate-limit error.

Ref: https://github.com/terascope/workflows/issues/65